### PR TITLE
Add xcore.ai explorer build to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,13 +35,12 @@ pipeline {
         //}
         stage('Build') {
           steps {
-            dir("${REPO}/app_usb_aud_xk_216_mc") {
-              viewEnv() {
-                sh 'xmake -j16 TEST_CONFIGS=1'
+            viewEnv() {
+              dir("${REPO}") {
+                sh 'xmake -C app_usb_aud_xk_216_mc -j16 TEST_CONFIGS=1'
+                stash includes: 'app_usb_aud_xk_216_mc/bin/**/*.xe', name: 'xk_216_mc_bin', useDefaultExcludes: false
+                sh 'xmake -C app_usb_aud_xk_evk_xu316 -j16 TEST_CONFIGS=1'
               }
-            }
-            dir("${REPO}") {
-              stash includes: 'app_usb_aud_xk_216_mc/bin/**/*.xe', name: 'xk_216_mc_bin', useDefaultExcludes: false
             }
           }
         }


### PR DESCRIPTION
This application already builds successfully with Tools 15.1.4, so just add it to the build stage of the Jenkins job to get build coverage in our automated tests. Using `xmake -C ...` makes it clearer in the Jenkins logs which application is being built.