### PR TITLE
Build documentation with xdoc during Jenkins job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,13 @@ pipeline {
                 sh 'xmake -C app_usb_aud_xk_216_mc -j16 TEST_CONFIGS=1'
                 stash includes: 'app_usb_aud_xk_216_mc/bin/**/*.xe', name: 'xk_216_mc_bin', useDefaultExcludes: false
                 sh 'xmake -C app_usb_aud_xk_evk_xu316 -j16 TEST_CONFIGS=1'
+
+                dir("doc") {
+                  sh 'xdoc xmospdf'
+                  dir("_build/xlatex") {
+                    archiveArtifacts artifacts: "index.pdf", fingerprint: true, allowEmptyArchive: true
+                  }
+                }
               }
             }
           }

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,8 +1,0 @@
-all : xmospdf xmoshtml
-
-DOXYGEN_DIRS=../../sc_xud ../../sc_spdif ../../sc_adat ../../lib_xua
-SOURCE_INCLUDE_DIRS=../../sw_usb_audio ../../lib_xua
-XDOC_DIR ?= ../../../xdoc
-BREADCRUMB_PREFIX=<li><a href="../../index.html">Home</a></li>
-include $(XDOC_DIR)/Makefile.inc
-REVISION=6.1

--- a/doc/xdoc.conf
+++ b/doc/xdoc.conf
@@ -1,0 +1,3 @@
+XMOSNEWSTYLE=2
+DOXYGEN_DIRS=../../lib_xud ../../lib_spdif ../../sc_adat ../../lib_xua
+SOURCE_INCLUDE_DIRS=../../sw_usb_audio ../../lib_xua


### PR DESCRIPTION
Build the documentation with xdoc during the Jenkins job. The viewfile has been updated to use xdoc v3.0.0 so `XMOSNEWSTYLE=2` works.