### PR TITLE
Support xk_216_mc HID buttons on Windows

### DIFF
--- a/app_usb_aud_xk_216_mc/src/core/user_main.h
+++ b/app_usb_aud_xk_216_mc/src/core/user_main.h
@@ -1,0 +1,14 @@
+#ifndef USER_MAIN_H
+#define USER_MAIN_H
+
+#ifdef __XC__
+
+void UserHIDPoll();
+
+#define USER_MAIN_CORES on tile[XUD_TILE]: {\
+                                        UserHIDPoll();\
+                                    }
+
+#endif
+
+#endif

--- a/app_usb_aud_xk_216_mc/src/core/xua_conf.h
+++ b/app_usb_aud_xk_216_mc/src/core/xua_conf.h
@@ -135,4 +135,6 @@
 #define HID_CONTROLS       1
 #endif
 
+#include "user_main.h"
+
 #endif

--- a/app_usb_aud_xk_216_mc/src/extensions/hidbuttons.xc
+++ b/app_usb_aud_xk_216_mc/src/extensions/hidbuttons.xc
@@ -4,9 +4,10 @@
 
 #include "app_usb_aud_xk_216_mc.h"
 #include "user_hid.h"
+#include "xua_hid_report.h"
 
 #if HID_CONTROLS > 0
-in port p_sw = on tile[1] : XS1_PORT_4B;
+in port p_sw = on tile[XUD_TILE] : XS1_PORT_4B;
 
 #define P_GPI_BUTA_SHIFT        0x00
 #define P_GPI_BUTA_MASK         (1<<P_GPI_BUTA_SHIFT)
@@ -33,14 +34,15 @@ unsigned wait_counter =0;
 
 
 #define THRESH 1
-#define MULTIPRESS_WAIT 25
+#define MULTIPRESS_WAIT_MS 200
+#define HIDBUTTONS_POLL_MS   1
 
-#define HID_CONTROL_NEXT 		0x02
-#define HID_CONTROL_PLAYPAUSE 	0x01
-#define HID_CONTROL_PREV		0x04
-#define HID_CONTROL VOLUP       0x08
-#define HID_CONTROL_VOLDN		0x10
-#define HID_CONTROL_MUTE		0x20
+#define HID_CONTROL_PLAYPAUSE   0x01
+#define HID_CONTROL_NEXT        0x02
+#define HID_CONTROL_PREV        0x04
+#define HID_CONTROL_VOLUP       0x08
+#define HID_CONTROL_VOLDN       0x10
+#define HID_CONTROL_MUTE        0x20
 
 typedef enum
 {
@@ -53,73 +55,99 @@ t_controlState state;
 
 unsigned lastA;
 
+static unsigned char lastHidData;
+
+void UserHIDPoll()
+{
+    state = STATE_IDLE;
+
+    while (1) {
+        delay_milliseconds(HIDBUTTONS_POLL_MS);
+
+        if (hidIsChangePending(0))
+            continue;
+
+        /* Variables for buttons a, b, c and switch sw */
+        unsigned a, b, c, sw, tmp;
+
+        p_sw :> tmp;
+
+        /* Buttons are active low */
+        tmp = ~tmp;
+
+        a = (tmp & (P_GPI_BUTA_MASK))>>P_GPI_BUTA_SHIFT;
+        b = (tmp & (P_GPI_BUTB_MASK))>>P_GPI_BUTB_SHIFT;
+        c = (tmp & (P_GPI_BUTC_MASK))>>P_GPI_BUTC_SHIFT;
+        sw = (tmp & (P_GPI_SW1_MASK))>>P_GPI_SW1_SHIFT;
+
+        unsigned char hidData = 0;
+
+        if(sw)
+        {
+            /* Assign buttons A and B to Vol Down/Up */
+            hidData |= a * HID_CONTROL_VOLDN;
+            hidData |= b * HID_CONTROL_VOLUP;
+            hidData |= c * HID_CONTROL_MUTE;
+        }
+        else
+        {
+            /* Assign buttons A and B to play for single tap, next/prev for double tap */
+            if(b)
+            {
+                multicontrol_count++;
+                wait_counter = 0;
+                lastA = 0;
+            }
+            else if(a)
+            {
+                multicontrol_count++;
+                wait_counter = 0;
+                lastA = 1;
+            }
+            else
+            {
+                if(multicontrol_count > THRESH)
+                {
+                    state++;
+                }
+
+                wait_counter++;
+
+                if(wait_counter > (MULTIPRESS_WAIT_MS / HIDBUTTONS_POLL_MS))
+                {
+                    if(state == STATE_PLAY)
+                    {
+                        hidData = HID_CONTROL_PLAYPAUSE;
+                    }
+                    else if(state == STATE_NEXTPREV)
+                    {
+                        if(lastA)
+                            hidData = HID_CONTROL_PREV;
+                        else
+                            hidData = HID_CONTROL_NEXT;
+                    }
+                    state = STATE_IDLE;
+                }
+                multicontrol_count = 0;
+            }
+        }
+
+        if (hidData == lastHidData)
+            continue;
+
+        unsafe {
+            volatile unsigned char * unsafe lastHidDataUnsafe = &lastHidData;
+            *lastHidDataUnsafe = hidData;
+            hidSetChangePending(0);
+        }
+    }
+}
+
 size_t UserHIDGetData( const unsigned id, unsigned char hidData[ HID_MAX_DATA_BYTES ])
 {
     // There is only one report, so the id parameter is ignored
 
-    /* Variables for buttons a, b, c and switch sw */
-    unsigned a, b, c, sw, tmp;
-
-    p_sw :> tmp;
-
-    /* Buttons are active low */
-    tmp = ~tmp;
-
-    a = (tmp & (P_GPI_BUTA_MASK))>>P_GPI_BUTA_SHIFT;
-    b = (tmp & (P_GPI_BUTB_MASK))>>P_GPI_BUTB_SHIFT;
-    c = (tmp & (P_GPI_BUTC_MASK))>>P_GPI_BUTC_SHIFT;
-    sw = (tmp & (P_GPI_SW1_MASK))>>P_GPI_SW1_SHIFT;
-
-    if(sw)
-    {
-        /* Assign buttons A and B to Vol Up/Down */
-        hidData[0] = (a << 4) | (b << 3) | (c << 5);
-    }
-    else
-    {
-        // Initialise data to zero for the cases where no actions are reported
-        hidData[0] = 0;
-
-        /* Assign buttons A and B to play for single tap, next/prev for double tap */
-        if(b)
-        {
-            multicontrol_count++;
-        	wait_counter = 0;
-            lastA = 0;
-    	}
-        else if(a)
-        {
-            multicontrol_count++;
-        	wait_counter = 0;
-            lastA = 1;
-        }
-        else
-        {
-    	    if(multicontrol_count > THRESH)
-    	    {
-    	    	state++;
-    	    }
-
-    	    wait_counter++;
-
-    	    if(wait_counter > MULTIPRESS_WAIT)
-            {
-    		    if(state == STATE_PLAY)
-                {
-    			    hidData[0] = HID_CONTROL_PLAYPAUSE;
-    		    }
-    		    else if(state == STATE_NEXTPREV)
-                {
-                    if(lastA)
-    			        hidData[0] = HID_CONTROL_PREV;
-    		        else
-    			        hidData[0] = HID_CONTROL_NEXT;
-                }
-    		    state = STATE_IDLE;
-    	    }
-    	    multicontrol_count = 0;
-        }
-    }
+    hidData[0] = lastHidData;
 
     // One byte of data is always returned
     return 1;
@@ -127,7 +155,6 @@ size_t UserHIDGetData( const unsigned id, unsigned char hidData[ HID_MAX_DATA_BY
 
 void UserHIDInit( void )
 {
-    state = STATE_IDLE;
 }
 
 #endif  // HID_CONTROLS > 0


### PR DESCRIPTION
Added `UserHIDPoll()` which checks the buttons and performs the logic to determine the HID data that used to be in `UserHIDGetData()`. When the HID data has changed, the latest value is stored in a global to be read by `UserHIDGetData()` - either when regularly polled by XUA (on Mac) or when the app reports a change to XUA (on Windows).

The 200ms multi-press wait and the 1ms polling interval give an experience on Mac and Windows which feels similar to the way the 6.15.2 release behaves.