### PR TITLE
Add Makefile option for safe parallel builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
                 sh 'xmake -C app_usb_aud_xk_216_mc -j16 TEST_CONFIGS=1'
                 stash includes: 'app_usb_aud_xk_216_mc/bin/**/*.xe', name: 'xk_216_mc_bin', useDefaultExcludes: false
 
-                sh 'xmake -C app_usb_aud_xk_evk_xu316 -j4 TEST_CONFIGS=1'
+                sh 'xmake -C app_usb_aud_xk_evk_xu316 -j16 TEST_CONFIGS=1'
                 stash includes: 'app_usb_aud_xk_evk_xu316/bin/**/*.xe', name: 'xk_evk_xu316_bin', useDefaultExcludes: false
 
                 dir("doc") {

--- a/app_usb_aud_xk_216_mc/Makefile
+++ b/app_usb_aud_xk_216_mc/Makefile
@@ -6,7 +6,8 @@ TARGET = xk-audio-216-mc.xn
 APP_NAME =
 
 # The flags passed to xcc when building the application
-BUILD_FLAGS     = -DFLASH_MAX_UPGRADE_SIZE=64*1024 -fcomment-asm -Xmapper --map -Xmapper MAPFILE -O3 -report -lquadflash -save-temps -g -fxscope -march=xs2a -DUSB_TILE=tile[1] -DADAT_TX_USE_SHARED_BUFF=1 -DQUAD_SPI_FLASH=1
+# The EXTRA_BUILD_FLAGS variable can be used on the xmake command line to add options
+BUILD_FLAGS    = $(EXTRA_BUILD_FLAGS) -DFLASH_MAX_UPGRADE_SIZE=64*1024 -fcomment-asm -Xmapper --map -Xmapper MAPFILE -O3 -report -lquadflash -g -fxscope -march=xs2a -DUSB_TILE=tile[1] -DADAT_TX_USE_SHARED_BUFF=1 -DQUAD_SPI_FLASH=1
 
 # The USED_MODULES variable lists other module used by the application. These
 # modules will extend the SOURCE_DIRS, INCLUDE_DIRS and LIB_DIRS variables. 

--- a/app_usb_aud_xk_evk_xu316/Makefile
+++ b/app_usb_aud_xk_evk_xu316/Makefile
@@ -6,7 +6,8 @@ TARGET = XCORE-AI-EXPLORER.xn
 APP_NAME =
 
 # The flags passed to xcc when building the application
-BUILD_FLAGS     = -DFLASH_MAX_UPGRADE_SIZE=64*1024 -fcomment-asm -Xmapper --map -Xmapper MAPFILE -Wall -O3 -report -lquadflash -save-temps -g -fxscope -DXSCOPE -DUSB_TILE=tile[0] -DADAT_TX_USE_SHARED_BUFF=1 -DQUAD_SPI_FLASH=1 -DUAC_FORCE_FEEDBACK_EP=1
+# The EXTRA_BUILD_FLAGS variable can be used on the xmake command line to add options
+BUILD_FLAGS    = $(EXTRA_BUILD_FLAGS) -DFLASH_MAX_UPGRADE_SIZE=64*1024 -fcomment-asm -Xmapper --map -Xmapper MAPFILE -Wall -O3 -report -lquadflash -g -fxscope -DXSCOPE -DUSB_TILE=tile[0] -DADAT_TX_USE_SHARED_BUFF=1 -DQUAD_SPI_FLASH=1 -DUAC_FORCE_FEEDBACK_EP=1
 
 # The USED_MODULES variable lists other module used by the application. These
 # modules will extend the SOURCE_DIRS, INCLUDE_DIRS and LIB_DIRS variables.


### PR DESCRIPTION
I've seen a parallel xmake build failure on the xcore200 app. There is an [existing bug](http://bugzilla/show_bug.cgi?id=16751) that the `-j` option to xmake isn't safe when xcc sets `-save-temps`.

`-save-temps` is useful during development to get the .s and .xi files from a build.

The only place we really need parallel builds in practice is during the Jenkins run, because otherwise the apps would take too long to build:
 - non-parallel build time for all configs of both apps: ~28mins
 - parallel build of the same: ~3mins

So I propose adding a Makefile option that we can set on the Jenkins run to omit the `-save-temps` option so that builds can be performed in parallel.