### PR TITLE
Add DFU test case for xcore.ai explorer

### DIFF
--- a/tests/test_dfu.py
+++ b/tests/test_dfu.py
@@ -85,10 +85,18 @@ def create_dfu_bin(board, config):
     return dfu_bin_path
 
 
-@pytest.mark.smoke
-@pytest.mark.nightly
-@pytest.mark.weekend
-@pytest.mark.parametrize(["board", "config"], [("xk_216_mc", "2i10o10xxxxxx")])
+# Test cases are defined by a tuple of (board, initial config to xflash)
+dfu_testcases = [
+    pytest.param("xk_216_mc", "2i10o10xxxxxx", marks=[pytest.mark.smoke,
+                                                      pytest.mark.nightly,
+                                                      pytest.mark.weekend]),
+
+    pytest.param("xk_evk_xu316", "2i2o2",      marks=[pytest.mark.nightly,
+                                                      pytest.mark.weekend])
+]
+
+
+@pytest.mark.parametrize(["board", "config"], dfu_testcases)
 def test_dfu(xtagctl_wrapper, xmosdfu, board, config):
     adapter_dut, _ = xtagctl_wrapper
 


### PR DESCRIPTION
Added a testcase for the xk_evk_xu316 now that the DFU download works and I've run the DFU test sequence successfully. A single run of test_dfu() takes about three minutes, so to save time I'm only putting the xk_216_mc in the smoke level - when we have the xcore.ai MCAB I would probably use that instead since it will be our "main" app. They can all be tested on nightly and weekend runs since we aren't time-restricted on them.