### PR TITLE
Set MAX_MIX_COUNT to 0 (from 2) in app_usb_aud_xk_evk_xu316

### DIFF
--- a/app_usb_aud_xk_evk_xu316/src/core/xua_defs.h
+++ b/app_usb_aud_xk_evk_xu316/src/core/xua_defs.h
@@ -31,7 +31,7 @@
 
 /* Mixing disabled by default */
 #ifndef MAX_MIX_COUNT
-#define MAX_MIX_COUNT      (2)
+#define MAX_MIX_COUNT      (0)
 #endif
 
 /* Board is self-powered i.e. not USB bus-powered */


### PR DESCRIPTION
Reduces risk of hitting https://github.com/xmos/lib_xua/issues/267

Additionally we currently are not running mixer in regression 
