### PR TITLE
Update the restart_check() to add restart = I2S_NO_RESTART, otherwise…

### DIFF
--- a/app_usb_aud_xk_evk_xu316_extrai2s/src/extensions/extra_i2s.xc
+++ b/app_usb_aud_xk_evk_xu316_extrai2s/src/extensions/extra_i2s.xc
@@ -85,6 +85,7 @@ void i2s_data(server i2s_frame_callback_if i_i2s, chanend c)
 
             case i_i2s.restart_check() -> i2s_restart_t restart:
                 // Inform the I2S slave whether it should restart or exit
+                restart = I2S_NO_RESTART;
                 break;
 
             case i_i2s.receive(size_t num_in, int32_t samples[num_in]):


### PR DESCRIPTION
…, the i2s frame slave will spend 3x time to send receive()

See also https://github.com/xmos/lib_i2s/issues/116