### PR TITLE
Automated testing updates to support new Mac hardware agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.18.0') _
+@Library('xmos_jenkins_shared_library@v0.19.0') _
 
 getApproval()
 
@@ -18,7 +18,7 @@ pipeline {
   stages {
     stage('Create release and build') {
       agent {
-        label '(linux || macOS) && x86_64'
+        label 'macOS && x86_64'
       }
       stages {
         stage('Get view') {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# python_version 3.7.6
+# python_version 3.9.0
 
 pytest==7.1.2
 requests==2.27.1


### PR DESCRIPTION
- Updated to use Python 3.9.0 as Python 3.7 doesn't appear to be supported on MacOS Monterey. I wanted to use 3.10.5, but that isn't available on the other Jenkins agents which perform the builds (the python environment shouldn't even be required for the builds, but the Jenkins shared library function we use to setup the sandbox installs it). Also there is one Linux agent (vilgax) that doesn't seem to be able to install Python 3.9.0, so I've changed the build agent to be MacOS only.
- Also updated the Jenkins shared library to the latest release version 0.19.0

There are further improvements that can be made to cleanup some of the existing Jenkins-specific code, but they worked when I ran them manually but failed when run by Jenkins. It would be time-consuming to debug that, so I'm going to leave that for now so that we can get this system back up and running.