### PR TITLE
Update Python version to 3.10.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
   stages {
     stage('Create release and build') {
       agent {
-        label 'macOS && x86_64'
+        label '(linux || macOS) && x86_64'
       }
       stages {
         stage('Get view') {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# python_version 3.9.0
+# python_version 3.10.5
 
 pytest==7.1.2
 requests==2.27.1


### PR DESCRIPTION
The problematic Jenkins agent (vilgax) which prevented use of Python 3.10.5 has been decommissioned and this version is now available across the build and test agents.