### PR TITLE
XTAG selection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ pytest==7.1.2
 requests==2.27.1
 sh==1.14.2
 sounddevice==0.4.4
-
--e ../xtagctl

--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -100,9 +100,9 @@ analogue_input_configs = [
 
 
 @pytest.mark.parametrize(["board", "config", "fs", "duration", "xsig_config"], analogue_input_configs)
-def test_analogue_input(xtagctl_wrapper, xsig, board, config, fs, duration, xsig_config):
+def test_analogue_input(xtag_wrapper, xsig, board, config, fs, duration, xsig_config):
     xsig_config_path = Path(__file__).parent / 'xsig_configs' / xsig_config
-    adapter_dut, adapter_harness = xtagctl_wrapper
+    adapter_dut, adapter_harness = xtag_wrapper
 
     # xrun the harness
     harness_firmware = get_firmware_path_harness("xcore200_mc")
@@ -203,9 +203,9 @@ analogue_output_configs = [
 
 
 @pytest.mark.parametrize(["board", "config", "fs", "duration", "xsig_config"], analogue_output_configs)
-def test_analogue_output(xtagctl_wrapper, xsig, board, config, fs, duration, xsig_config):
+def test_analogue_output(xtag_wrapper, xsig, board, config, fs, duration, xsig_config):
     xsig_config_path = Path(__file__).parent / 'xsig_configs' / xsig_config
-    adapter_dut, adapter_harness = xtagctl_wrapper
+    adapter_dut, adapter_harness = xtag_wrapper
 
     # xrun the dut
     firmware = get_firmware_path(board, config)

--- a/tests/test_dfu.py
+++ b/tests/test_dfu.py
@@ -67,8 +67,8 @@ dfu_testcases = [
 
 
 @pytest.mark.parametrize(["board", "config"], dfu_testcases)
-def test_dfu(xtagctl_wrapper, xmosdfu, board, config):
-    adapter_dut, _ = xtagctl_wrapper
+def test_dfu(xtag_wrapper, xmosdfu, board, config):
+    adapter_dut, _ = xtag_wrapper
 
     vid = 0x20B1
     pid = 0x8

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -63,7 +63,7 @@ volume_input_configs = [
 
 
 @pytest.mark.parametrize(["board", "config", "fs", "channel"], volume_input_configs)
-def test_volume_input(xtagctl_wrapper, xsig, board, config, fs, channel):
+def test_volume_input(xtag_wrapper, xsig, board, config, fs, channel):
     if board == "xk_216_mc":
         num_chans = 8
     elif board == "xk_evk_xu316":
@@ -85,7 +85,7 @@ def test_volume_input(xtagctl_wrapper, xsig, board, config, fs, channel):
         if ch in channels:
             xsig_json["in"][ch][0] = "volcheck"
 
-    adapter_dut, adapter_harness = xtagctl_wrapper
+    adapter_dut, adapter_harness = xtag_wrapper
 
     # xrun the harness
     harness_firmware = get_firmware_path_harness("xcore200_mc")
@@ -149,7 +149,7 @@ volume_output_configs = [
 
 
 @pytest.mark.parametrize(["board", "config", "fs", "channel"], volume_output_configs)
-def test_volume_output(xtagctl_wrapper, xsig, board, config, fs, channel):
+def test_volume_output(xtag_wrapper, xsig, board, config, fs, channel):
     if board == 'xk_216_mc':
         num_chans = 8
     elif board == 'xk_evk_xu316':
@@ -162,7 +162,7 @@ def test_volume_output(xtagctl_wrapper, xsig, board, config, fs, channel):
     xsig_config = f'mc_analogue_output_{num_chans}ch.json'
     xsig_config_path = Path(__file__).parent / "xsig_configs" / xsig_config
 
-    adapter_dut, adapter_harness = xtagctl_wrapper
+    adapter_dut, adapter_harness = xtag_wrapper
 
     # xrun the dut
     firmware = get_firmware_path(board, config)


### PR DESCRIPTION
This is in preparation for running on multiple Jenkins agents with different hardware attached to each. The Jenkinsfile will be the source-of-truth for what hardware is attached to each agent, and then the hardware is selected by setting command-line options to pytest (tests on other hardware are skipped).

`xtagctl` is no longer a direct requirement for running the tests, so a user running locally does not need it, which is good because it's not a public repo. We only need it for Jenkins testing to be able to get the XTAG IDs that are attached to specific types of devices.

I have also tested with pytest failures to ensure that the XTAGs are released.