### PR TITLE
Add xk_316_mc testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,8 @@ pipeline {
           steps {
             viewEnv() {
               dir("${REPO}") {
-                sh 'xmake -C app_usb_aud_xk_316_mc -j16'
+                sh 'xmake -C app_usb_aud_xk_316_mc -j16 TEST_CONFIGS=1'
+                stash includes: 'app_usb_aud_xk_316_mc/bin/**/*.xe', name: 'xk_316_mc_bin', useDefaultExcludes: false
  
                 sh 'xmake -C app_usb_aud_xk_216_mc -j16 TEST_CONFIGS=1'
                 stash includes: 'app_usb_aud_xk_216_mc/bin/**/*.xe', name: 'xk_216_mc_bin', useDefaultExcludes: false
@@ -86,44 +87,48 @@ pipeline {
       }
     }
     stage('Regression Test') {
-      agent {
-        label 'usb_audio'
-      }
-      stages {
-        stage('Get view') {
-          steps {
-            xcorePrepareSandbox("${VIEW}", "${REPO}")
+      parallel {
+        stage('MacOS Intel') {
+          agent {
+            label 'usb_audio && macos && x86_64 && xcore200-mcab && xcore.ai-explorer'
           }
-        }
-        stage('Test') {
-          steps {
-            dir("${WORKSPACE}/sw_audio_analyzer") {
-              copyArtifacts filter: '**/*.xe', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
-              copyArtifacts filter: 'host_xscope_controller/bin_macos/xscope_controller', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+          stages {
+            stage('Get view') {
+              steps {
+                xcorePrepareSandbox("${VIEW}", "${REPO}")
+              }
             }
-            dir("${REPO}") {
-              unstash 'xk_216_mc_bin'
-              unstash 'xk_evk_xu316_bin'
-              dir("tests") {
-                // Build test support application
-                sh 'make -C tools/volcontrol'
-
-                dir("tools") {
-                  copyArtifacts filter: 'bin_macos/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
+            stage('Test') {
+              steps {
+                dir("${WORKSPACE}/sw_audio_analyzer") {
+                  copyArtifacts filter: '**/*.xe', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+                  copyArtifacts filter: 'host_xscope_controller/bin_macos/xscope_controller', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
                 }
+                dir("${REPO}") {
+                  unstash 'xk_216_mc_bin'
+                  unstash 'xk_evk_xu316_bin'
+                  dir("tests") {
+                    // Build test support application
+                    sh 'make -C tools/volcontrol'
 
-                viewEnv() {
-                  // The JENKINS env var is necessary for macOS catalina
-                  // We have to work around microphone permission issues
-                  // For more info, see the DevOps section of the XMOS wiki
-                  withEnv(["JENKINS=1"]) {
-                    withVenv() {
-                      sh "pip install -e ${WORKSPACE}/xtagctl"
-                      withXTAG(["usb_audio_mc_xs2_dut", "usb_audio_mc_xs2_harness", \
-                                "usb_audio_xcai_exp_dut", "usb_audio_xcai_exp_harness"]) { xtagIds ->
-                        sh "pytest -m ${params.TEST_LEVEL} --junitxml=pytest_result.xml \
-                            --xk-216-mc-dut=${xtagIds[0]} --xk-216-mc-harness=${xtagIds[1]} \
-                            --xk-evk-xu316-dut=${xtagIds[2]} --xk-evk-xu316-harness=${xtagIds[3]}"
+                    dir("tools") {
+                      copyArtifacts filter: 'bin_macos/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
+                    }
+
+                    viewEnv() {
+                      // The JENKINS env var is necessary for macOS catalina
+                      // We have to work around microphone permission issues
+                      // For more info, see the DevOps section of the XMOS wiki
+                      withEnv(["JENKINS=1"]) {
+                        withVenv() {
+                          sh "pip install -e ${WORKSPACE}/xtagctl"
+                          withXTAG(["usb_audio_mc_xs2_dut", "usb_audio_mc_xs2_harness", \
+                                    "usb_audio_xcai_exp_dut", "usb_audio_xcai_exp_harness"]) { xtagIds ->
+                            sh "pytest -m ${params.TEST_LEVEL} --junitxml=pytest_result.xml \
+                                -o xk_216_mc_dut=${xtagIds[0]} -o xk_216_mc_harness=${xtagIds[1]} \
+                                -o xk_evk_xu316_dut=${xtagIds[2]} -o xk_evk_xu316_harness=${xtagIds[3]}"
+                          }
+                        }
                       }
                     }
                   }
@@ -131,11 +136,62 @@ pipeline {
               }
             }
           }
+          post {
+            cleanup {
+              cleanWs()
+            }
+          }
         }
-      }
-      post {
-        cleanup {
-          cleanWs()
+        stage('MacOS ARM') {
+          agent {
+            label 'usb_audio && macos && arm64 && xcore.ai-mcab'
+          }
+          stages {
+            stage('Get view') {
+              steps {
+                xcorePrepareSandbox("${VIEW}", "${REPO}")
+              }
+            }
+            stage('Test') {
+              steps {
+                dir("${WORKSPACE}/sw_audio_analyzer") {
+                  copyArtifacts filter: '**/*.xe', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+                  copyArtifacts filter: 'host_xscope_controller/bin_macos/xscope_controller', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+                }
+                dir("${REPO}") {
+                  unstash 'xk_316_mc_bin'
+                  dir("tests") {
+                    // Build test support application
+                    sh 'make -C tools/volcontrol'
+
+                    dir("tools") {
+                      copyArtifacts filter: 'bin_macos_m1/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
+                    }
+
+                    viewEnv() {
+                      // The JENKINS env var is necessary for macOS catalina
+                      // We have to work around microphone permission issues
+                      // For more info, see the DevOps section of the XMOS wiki
+                      withEnv(["JENKINS=1"]) {
+                        withVenv() {
+                          sh "pip install -e ${WORKSPACE}/xtagctl"
+                          withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
+                            sh "pytest -m ${params.TEST_LEVEL} --junitxml=pytest_result.xml \
+                                -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]}"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          post {
+            cleanup {
+              cleanWs()
+            }
+          }
         }
       }
     }

--- a/app_usb_aud_xk_316_mc/Makefile
+++ b/app_usb_aud_xk_316_mc/Makefile
@@ -96,6 +96,11 @@ XCC_FLAGS_2Si10o10xxxxxx_tdm8 = $(BUILD_FLAGS)	-DXUA_PCM_FORMAT=XUA_PCM_FORMAT_T
 INCLUDE_ONLY_IN_2Si10o10xxxxxx_tdm8 = 
 
 
+ifeq ($(TEST_CONFIGS),1)
+XCC_FLAGS_upgrade1 = $(BUILD_FLAGS) -DBCD_DEVICE_J=0x99 -DBCD_DEVICE_M=0x0 -DBCD_DEVICE_N=0x1
+XCC_FLAGS_upgrade2 = $(BUILD_FLAGS) -DBCD_DEVICE_J=0x99 -DBCD_DEVICE_M=0x0 -DBCD_DEVICE_N=0x2
+endif
+
 #=============================================================================
 # The following part of the Makefile includes the common build infrastructure
 # for compiling XMOS applications. You should not need to edit below here.

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -4,3 +4,12 @@ markers =
     smoke: test included in shortest coverage level
     nightly: test included in nightly coverage level
     weekend: test included in weekend coverage level
+
+# XTAG IDs for the boards in the test setup can be hard-coded here to avoid having to specify
+# them on the pytest command-line for a fixed local setup, eg. xk_216_mc_dut = RdZ15gCf
+xk_216_mc_dut =
+xk_216_mc_harness =
+xk_316_mc_dut =
+xk_316_mc_harness =
+xk_evk_xu316_dut =
+xk_evk_xu316_harness =

--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -25,8 +25,12 @@ analogue_input_configs = [
         ('xk_216_mc', '2Ai10o10xsxxxx_mix8',    192000, 10, "mc_analogue_input_8ch.json"),
         ('xk_216_mc', '2Ai10o10xssxxx',         192000, 10, "mc_analogue_input_8ch.json"),
         ('xk_216_mc', '2Si10o10xxxxxx',         192000, 10, "mc_analogue_input_8ch.json"),
-        ('xk_evk_xu316', '1i2o2',               48000, 10, "mc_analogue_input_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',               48000, 10, "mc_analogue_input_2ch.json")
+        ('xk_316_mc', '1Ai2o2xxxxxx',            48000, 10, "mc_analogue_input_2ch.json"),
+        ('xk_316_mc', '2Ai10o10xxxxxx',          96000, 10, "mc_analogue_input_8ch.json"),
+        ('xk_316_mc', '2Ai10o10xsxxxx',         192000, 10, "mc_analogue_input_8ch.json"),
+        ('xk_316_mc', '2Si10o10xxxxxx',         192000, 10, "mc_analogue_input_8ch.json"),
+        ('xk_evk_xu316', '1i2o2',                48000, 10, "mc_analogue_input_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',                48000, 10, "mc_analogue_input_2ch.json")
     ]),
 
     # nightly level tests
@@ -43,9 +47,13 @@ analogue_input_configs = [
         ('xk_216_mc', '2Ai10o10xsxxxd',           48000, 600, "mc_analogue_input_8ch.json"),
         ('xk_216_mc', '2Ai10o10xsxxxd',          192000, 600, "mc_analogue_input_8ch.json"),
         ('xk_216_mc', '2Si10o10xxxxxx',          192000, 600, "mc_analogue_input_8ch.json"),
-        ('xk_evk_xu316', '1i2o2',                 44100, 600, "mc_analogue_input_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',                 44100, 600, "mc_analogue_input_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',                192000, 600, "mc_analogue_input_2ch.json")
+        ('xk_316_mc', '1Ai2o2xxxxxx',             44100, 600, "mc_analogue_input_2ch.json"),
+        ('xk_316_mc', '1Si2o2xxxxxx',             88200, 600, "mc_analogue_input_2ch.json"),
+        ('xk_316_mc', '2Ai10o10xxxxxx',          192000, 600, "mc_analogue_input_8ch.json"),
+        ('xk_316_mc', '2Ai10o10xsxxxx',           48000, 600, "mc_analogue_input_8ch.json"),
+        ('xk_evk_xu316',  '1i2o2',                44100, 600, "mc_analogue_input_2ch.json"),
+        ('xk_evk_xu316',  '2i2o2',                44100, 600, "mc_analogue_input_2ch.json"),
+        ('xk_evk_xu316',  '2i2o2',               192000, 600, "mc_analogue_input_2ch.json")
     ]),
 
     # weekend level tests
@@ -89,12 +97,22 @@ analogue_input_configs = [
         ('xk_216_mc', '2Si10o10xxxxxx',           48000, 1800, "mc_analogue_input_8ch.json"),
         ('xk_216_mc', '2Si10o10xxxxxx',          176400, 1800, "mc_analogue_input_8ch.json"),
         ('xk_216_mc', '2Si10o10xxxxxx',          192000, 1800, "mc_analogue_input_8ch.json"),
-        ('xk_evk_xu316', '1i2o2',                44100, 1800, "mc_analogue_input_2ch.json"),
-        ('xk_evk_xu316', '1i2o2',                48000, 1800, "mc_analogue_input_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',                44100, 1800, "mc_analogue_input_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',                88200, 1800, "mc_analogue_input_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',                96000, 1800, "mc_analogue_input_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',               176400, 1800, "mc_analogue_input_2ch.json")
+        ('xk_316_mc', '1Ai2o2xxxxxx',             44100, 1800, "mc_analogue_input_2ch.json"),
+        ('xk_316_mc', '1Ai2o2xxxxxx',             48000, 1800, "mc_analogue_input_2ch.json"),
+        ('xk_316_mc', '1Si2o2xxxxxx',             44100, 1800, "mc_analogue_input_2ch.json"),
+        ('xk_316_mc', '1Si2o2xxxxxx',             48000, 1800, "mc_analogue_input_2ch.json"),
+        ('xk_316_mc', '2Ai10o10xxxxxx',          176400, 1800, "mc_analogue_input_8ch.json"),
+        ('xk_316_mc', '2Ai10o10xxxxxx',          192000, 1800, "mc_analogue_input_8ch.json"),
+        ('xk_316_mc', '2Ai10o10xsxxxx',           88200, 1800, "mc_analogue_input_8ch.json"),
+        ('xk_316_mc', '2Ai10o10xsxxxx',           96000, 1800, "mc_analogue_input_8ch.json"),
+        ('xk_316_mc', '2Si10o10xxxxxx',           44100, 1800, "mc_analogue_input_8ch.json"),
+        ('xk_316_mc', '2Si10o10xxxxxx',           96000, 1800, "mc_analogue_input_8ch.json"),
+        ('xk_evk_xu316', '1i2o2',                 44100, 1800, "mc_analogue_input_2ch.json"),
+        ('xk_evk_xu316', '1i2o2',                 48000, 1800, "mc_analogue_input_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',                 44100, 1800, "mc_analogue_input_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',                 88200, 1800, "mc_analogue_input_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',                 96000, 1800, "mc_analogue_input_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',                176400, 1800, "mc_analogue_input_2ch.json")
     ])
 ]
 
@@ -140,8 +158,12 @@ analogue_output_configs = [
         ('xk_216_mc', '2Ai10o10msxxxx',         192000, 10, "mc_analogue_output_8ch.json"),
         ('xk_216_mc', '2Ai10o10xsxxxx_mix8',    192000, 10, "mc_analogue_output_8ch.json"),
         ('xk_216_mc', '2Ai10o10xssxxx',         192000, 10, "mc_analogue_output_8ch.json"),
-        ('xk_evk_xu316', '1i2o2',               48000, 10, "mc_analogue_output_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',               48000, 10, "mc_analogue_output_2ch.json")
+        ('xk_316_mc', '1Ai2o2xxxxxx',            48000, 10, "mc_analogue_output_2ch.json"),
+        ('xk_316_mc', '2Ai10o10xxxxxx',          96000, 10, "mc_analogue_output_8ch.json"),
+        ('xk_316_mc', '2Ai10o10xsxxxx',         192000, 10, "mc_analogue_output_8ch.json"),
+        ('xk_316_mc', '2Si10o10xxxxxx',         192000, 10, "mc_analogue_output_8ch.json"),
+        ('xk_evk_xu316', '1i2o2',                48000, 10, "mc_analogue_output_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',                48000, 10, "mc_analogue_output_2ch.json")
     ]),
 
     # nightly level tests
@@ -155,9 +177,13 @@ analogue_output_configs = [
         ('xk_216_mc', '2Ai10o10msxxxx',          48000, 600, "mc_analogue_output_8ch.json"),
         ('xk_216_mc', '2Ai10o10xsxxxx_mix8',     48000, 600, "mc_analogue_output_8ch.json"),
         ('xk_216_mc', '2Ai10o10xssxxx',          48000, 600, "mc_analogue_output_8ch.json"),
-        ('xk_evk_xu316', '1i2o2',               44100, 600, "mc_analogue_output_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',               44100, 600, "mc_analogue_output_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',              192000, 600, "mc_analogue_output_2ch.json")
+        ('xk_316_mc', '1Ai2o2xxxxxx',            44100, 600, "mc_analogue_output_2ch.json"),
+        ('xk_316_mc', '1Si2o2xxxxxx',            88200, 600, "mc_analogue_output_2ch.json"),
+        ('xk_316_mc', '2Ai10o10xxxxxx',         192000, 600, "mc_analogue_output_8ch.json"),
+        ('xk_316_mc', '2Ai10o10xsxxxx',          48000, 600, "mc_analogue_output_8ch.json"),
+        ('xk_evk_xu316', '1i2o2',                44100, 600, "mc_analogue_output_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',                44100, 600, "mc_analogue_output_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',               192000, 600, "mc_analogue_output_2ch.json")
     ]),
 
     # weekend level tests
@@ -192,12 +218,22 @@ analogue_output_configs = [
         ('xk_216_mc', '2Ai10o10xssxxx',          88200, 1800, "mc_analogue_output_8ch.json"),
         ('xk_216_mc', '2Ai10o10xssxxx',          96000, 1800, "mc_analogue_output_8ch.json"),
         ('xk_216_mc', '2Ai10o10xssxxx',         176400, 1800, "mc_analogue_output_8ch.json"),
-        ('xk_evk_xu316', '1i2o2',               44100, 1800, "mc_analogue_output_2ch.json"),
-        ('xk_evk_xu316', '1i2o2',               48000, 1800, "mc_analogue_output_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',               44100, 1800, "mc_analogue_output_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',               88200, 1800, "mc_analogue_output_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',               96000, 1800, "mc_analogue_output_2ch.json"),
-        ('xk_evk_xu316', '2i2o2',              176400, 1800, "mc_analogue_output_2ch.json")
+        ('xk_316_mc', '1Ai2o2xxxxxx',            44100, 1800, "mc_analogue_output_2ch.json"),
+        ('xk_316_mc', '1Ai2o2xxxxxx',            48000, 1800, "mc_analogue_output_2ch.json"),
+        ('xk_316_mc', '1Si2o2xxxxxx',            44100, 1800, "mc_analogue_output_2ch.json"),
+        ('xk_316_mc', '1Si2o2xxxxxx',            48000, 1800, "mc_analogue_output_2ch.json"),
+        ('xk_316_mc', '2Ai10o10xxxxxx',         176400, 1800, "mc_analogue_output_8ch.json"),
+        ('xk_316_mc', '2Ai10o10xxxxxx',         192000, 1800, "mc_analogue_output_8ch.json"),
+        ('xk_316_mc', '2Ai10o10xsxxxx',          88200, 1800, "mc_analogue_output_8ch.json"),
+        ('xk_316_mc', '2Ai10o10xsxxxx',          96000, 1800, "mc_analogue_output_8ch.json"),
+        ('xk_316_mc', '2Si10o10xxxxxx',          44100, 1800, "mc_analogue_output_8ch.json"),
+        ('xk_316_mc', '2Si10o10xxxxxx',          96000, 1800, "mc_analogue_output_8ch.json"),
+        ('xk_evk_xu316', '1i2o2',                44100, 1800, "mc_analogue_output_2ch.json"),
+        ('xk_evk_xu316', '1i2o2',                48000, 1800, "mc_analogue_output_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',                44100, 1800, "mc_analogue_output_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',                88200, 1800, "mc_analogue_output_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',                96000, 1800, "mc_analogue_output_2ch.json"),
+        ('xk_evk_xu316', '2i2o2',               176400, 1800, "mc_analogue_output_2ch.json")
     ])
 ]
 

--- a/tests/test_dfu.py
+++ b/tests/test_dfu.py
@@ -88,12 +88,18 @@ dfu_testcases = [
         marks=[pytest.mark.smoke, pytest.mark.nightly, pytest.mark.weekend],
     ),
     pytest.param(
+        "xk_316_mc",
+        "2Ai10o10xxxxxx",
+        marks=[pytest.mark.smoke, pytest.mark.nightly, pytest.mark.weekend],
+    ),
+    pytest.param(
         "xk_evk_xu316", "2i2o2", marks=[pytest.mark.nightly, pytest.mark.weekend]
     ),
 ]
 
 pids = {
     "xk_216_mc": 0xE,
+    "xk_316_mc": 0x16,
     "xk_evk_xu316": 0x18,
 }
 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -34,20 +34,31 @@ class Volcontrol:
         time.sleep(3)
 
 
+num_chans = {
+    "xk_216_mc": 8,
+    "xk_316_mc": 8,
+    "xk_evk_xu316": 2,
+}
+
+
 # Test cases are defined by a tuple of (board, config, sample rate, 'm' (master) or channel number)
 volume_input_configs = [
     # smoke level tests
     *mark_tests(pytest.mark.smoke, [
         *[('xk_216_mc',    '2Ai10o10xxxxxx',        96000, ch) for ch in ['m', *range(8)]],
-        *[('xk_evk_xu316', '2i2o2',                48000, ch) for ch in ['m', *range(2)]]
+        *[('xk_316_mc',    '2Ai10o10xxxxxx',        96000, ch) for ch in ['m', *range(8)]],
+        *[('xk_evk_xu316', '2i2o2',                 48000, ch) for ch in ['m', *range(2)]]
     ]),
 
     # nightly level tests
     *mark_tests(pytest.mark.nightly, [
         *[('xk_216_mc',    '2Ai8o8xxxxx_tdm8',      48000, ch) for ch in ['m', *range(8)]],
         *[('xk_216_mc',    '2Ai10o10msxxxx',       192000, ch) for ch in ['m', *range(8)]],
-        *[('xk_evk_xu316', '2i2o2',                44100, ch) for ch in ['m', *range(2)]],
-        *[('xk_evk_xu316', '2i2o2',                96000, ch) for ch in ['m', *range(2)]]
+        *[('xk_316_mc',    '2Ai10o10xxxxxx',        48000, ch) for ch in ['m', *range(8)]],
+        *[('xk_316_mc',    '2Ai10o10xsxxxx',       192000, ch) for ch in ['m', *range(8)]],
+        *[('xk_316_mc',    '2Si10o10xxxxxx',        88200, ch) for ch in ['m', *range(8)]],
+        *[('xk_evk_xu316', '2i2o2',                 44100, ch) for ch in ['m', *range(2)]],
+        *[('xk_evk_xu316', '2i2o2',                 96000, ch) for ch in ['m', *range(2)]]
     ]),
 
     # weekend level tests
@@ -55,28 +66,24 @@ volume_input_configs = [
         *[('xk_216_mc',    '2Ai10o10xsxxxx_mix8',   44100, ch) for ch in ['m', *range(8)]],
         *[('xk_216_mc',    '2Ai10o10xssxxx',       176400, ch) for ch in ['m', *range(8)]],
         *[('xk_216_mc',    '2Si10o10xxxxxx',       192000, ch) for ch in ['m', *range(8)]],
-        *[('xk_evk_xu316', '2i2o2',                88200, ch) for ch in ['m', *range(2)]],
-        *[('xk_evk_xu316', '2i2o2',               176400, ch) for ch in ['m', *range(2)]],
-        *[('xk_evk_xu316', '2i2o2',               192000, ch) for ch in ['m', *range(2)]]
+        *[('xk_316_mc',    '2Ai10o10xxxxxx',        44100, ch) for ch in ['m', *range(8)]],
+        *[('xk_316_mc',    '2Ai10o10xsxxxx',       176400, ch) for ch in ['m', *range(8)]],
+        *[('xk_316_mc',    '2Si10o10xxxxxx',        96000, ch) for ch in ['m', *range(8)]],
+        *[('xk_evk_xu316', '2i2o2',                 88200, ch) for ch in ['m', *range(2)]],
+        *[('xk_evk_xu316', '2i2o2',                176400, ch) for ch in ['m', *range(2)]],
+        *[('xk_evk_xu316', '2i2o2',                192000, ch) for ch in ['m', *range(2)]]
     ])
 ]
 
 
 @pytest.mark.parametrize(["board", "config", "fs", "channel"], volume_input_configs)
 def test_volume_input(xtag_wrapper, xsig, board, config, fs, channel):
-    if board == "xk_216_mc":
-        num_chans = 8
-    elif board == "xk_evk_xu316":
-        num_chans = 2
-    else:
-        pytest.fail(f'Unrecognised board {board}')
-
-    channels = range(num_chans) if channel == "m" else [channel]
+    channels = range(num_chans[board]) if channel == "m" else [channel]
 
     duration = 25
 
     # Load JSON xsig_config data
-    xsig_config = f'mc_analogue_input_{num_chans}ch.json'
+    xsig_config = f'mc_analogue_input_{num_chans[board]}ch.json'
     xsig_config_path = Path(__file__).parent / "xsig_configs" / xsig_config
     with open(xsig_config_path) as file:
         xsig_json = json.load(file)
@@ -105,9 +112,9 @@ def test_volume_input(xtag_wrapper, xsig, board, config, fs, channel):
         time.sleep(5)
 
         if channel == 'm':
-            vol_in = Volcontrol('input', num_chans, master=True)
+            vol_in = Volcontrol('input', num_chans[board], master=True)
         else:
-            vol_in = Volcontrol('input', num_chans, channel=int(channel))
+            vol_in = Volcontrol('input', num_chans[board], channel=int(channel))
 
         vol_in.reset()
         vol_changes = [0.5, 1.0, 0.75, 1.0]
@@ -126,40 +133,40 @@ volume_output_configs = [
     # smoke level tests
     *mark_tests(pytest.mark.smoke, [
         *[('xk_216_mc',    '2Ai10o10xxxxxx',        96000, ch) for ch in ['m', *range(8)]],
-        *[('xk_evk_xu316', '2i2o2',                48000, ch) for ch in ['m', *range(2)]]
+        *[('xk_316_mc',    '2Ai10o10xxxxxx',        96000, ch) for ch in ['m', *range(8)]],
+        *[('xk_evk_xu316', '2i2o2',                 48000, ch) for ch in ['m', *range(2)]]
     ]),
 
     # nightly level tests
     *mark_tests(pytest.mark.nightly, [
         *[('xk_216_mc',    '2Ai8o8xxxxx_tdm8',      48000, ch) for ch in ['m', *range(8)]],
         *[('xk_216_mc',    '2Ai10o10msxxxx',       192000, ch) for ch in ['m', *range(8)]],
-        *[('xk_evk_xu316', '2i2o2',                44100, ch) for ch in ['m', *range(2)]],
-        *[('xk_evk_xu316', '2i2o2',                96000, ch) for ch in ['m', *range(2)]]
+        *[('xk_316_mc',    '2Ai10o10xxxxxx',        48000, ch) for ch in ['m', *range(8)]],
+        *[('xk_316_mc',    '2Ai10o10xsxxxx',       192000, ch) for ch in ['m', *range(8)]],
+        *[('xk_316_mc',    '2Si10o10xxxxxx',        88200, ch) for ch in ['m', *range(8)]],
+        *[('xk_evk_xu316', '2i2o2',                 44100, ch) for ch in ['m', *range(2)]],
+        *[('xk_evk_xu316', '2i2o2',                 96000, ch) for ch in ['m', *range(2)]]
     ]),
 
     # weekend level tests
     *mark_tests(pytest.mark.weekend, [
         *[('xk_216_mc',    '2Ai10o10xsxxxx_mix8',   44100, ch) for ch in ['m', *range(8)]],
         *[('xk_216_mc',    '2Ai10o10xssxxx',       176400, ch) for ch in ['m', *range(8)]],
-        *[('xk_evk_xu316', '2i2o2',                88200, ch) for ch in ['m', *range(2)]],
-        *[('xk_evk_xu316', '2i2o2',               176400, ch) for ch in ['m', *range(2)]],
-        *[('xk_evk_xu316', '2i2o2',               192000, ch) for ch in ['m', *range(2)]]
+        *[('xk_316_mc',    '2Ai10o10xxxxxx',        44100, ch) for ch in ['m', *range(8)]],
+        *[('xk_316_mc',    '2Ai10o10xsxxxx',       176400, ch) for ch in ['m', *range(8)]],
+        *[('xk_316_mc',    '2Si10o10xxxxxx',        96000, ch) for ch in ['m', *range(8)]],
+        *[('xk_evk_xu316', '2i2o2',                 88200, ch) for ch in ['m', *range(2)]],
+        *[('xk_evk_xu316', '2i2o2',                176400, ch) for ch in ['m', *range(2)]],
+        *[('xk_evk_xu316', '2i2o2',                192000, ch) for ch in ['m', *range(2)]]
     ])
 ]
 
 
 @pytest.mark.parametrize(["board", "config", "fs", "channel"], volume_output_configs)
 def test_volume_output(xtag_wrapper, xsig, board, config, fs, channel):
-    if board == 'xk_216_mc':
-        num_chans = 8
-    elif board == 'xk_evk_xu316':
-        num_chans = 2
-    else:
-        pytest.fail(f'Unrecognised board {board}')
+    channels = range(num_chans[board]) if channel == "m" else [channel]
 
-    channels = range(num_chans) if channel == "m" else [channel]
-
-    xsig_config = f'mc_analogue_output_{num_chans}ch.json'
+    xsig_config = f'mc_analogue_output_{num_chans[board]}ch.json'
     xsig_config_path = Path(__file__).parent / "xsig_configs" / xsig_config
 
     adapter_dut, adapter_harness = xtag_wrapper
@@ -191,9 +198,9 @@ def test_volume_output(xtag_wrapper, xsig, board, config, fs, channel):
     time.sleep(2)
 
     if channel == "m":
-        vol_out = Volcontrol("output", num_chans, master=True)
+        vol_out = Volcontrol("output", num_chans[board], master=True)
     else:
-        vol_out = Volcontrol("output", num_chans, channel=channel)
+        vol_out = Volcontrol("output", num_chans[board], channel=channel)
 
     vol_out.reset()
     vol_changes = [0.5, 1.0, 0.75, 1.0]

--- a/tests/usb_audio_test_utils.py
+++ b/tests/usb_audio_test_utils.py
@@ -17,17 +17,20 @@ def product_str_from_board_config(board, config):
             return 'XMOS xCORE-200 MC (UAC1.0)'
         elif config.startswith('2'):
             return 'XMOS xCORE-200 MC (UAC2.0)'
-        else:
-            pytest.fail(f"Unrecognised config {config} for {board}")
+    elif board == 'xk_316_mc':
+        if config.startswith('1'):
+            return 'XMOS xCORE-AI MC (UAC1.0)'
+        elif config.startswith('2'):
+            return 'XMOS xCORE-AI MC (UAC2.0)'
     elif board == 'xk_evk_xu316':
         if config.startswith('1'):
             return 'XMOS xCORE (UAC1.0)'
         elif config.startswith('2'):
             return 'XMOS xCORE (UAC2.0)'
-        else:
-            pytest.fail(f"Unrecognised config {config} for {board}")
     else:
         pytest.fail(f"Unrecognised board {board}")
+
+    pytest.fail(f"Unrecognised config {config} for {board}")
 
 
 def wait_for_portaudio(board, config, timeout=10):


### PR DESCRIPTION
- Added parallel stages in the Jenkinsfile to test on the Intel and M1 Mac Minis
- Added analogue, volume and DFU testcases for xk_316_mc
- Added 'upgrade1' and 'upgrade2' build configs for xk_316_mc for the DFU test
- Moved the location for hard-coding XTAG IDs from conftest.py into pytest.ini as this is a more standard location for setup info
- Now that we will have some tests that aren't run because the hardware isn't present, conftest.py has a function to deselect testcases based on which XTAG IDs you provide. This makes the pytest output much cleaner (not printing 's' for every skipped test) and the numbers of tests and progress indicators make more sense.