### PR TITLE
Replace Python sh with subprocess in analogue tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@
 
 pytest==7.1.2
 requests==2.27.1
-sh==1.14.2
 sounddevice==0.4.4


### PR DESCRIPTION
This change will be needed for Windows testing, but right now it helps for debugging the invalid sample rate failure I'm seeing on the 2Ai8o8xxxxx_tdm8 config because sh obscures some of the details and it's easier to see what's going on with subprocess. Also noticed that the harness wasn't being stopped in one of the analogue tests, so I've fixed that as well.