### PR TITLE
Add HID_CONTROLS preprocessor check around UserHIDPoll

### DIFF
--- a/app_usb_aud_xk_216_mc/src/core/user_main.h
+++ b/app_usb_aud_xk_216_mc/src/core/user_main.h
@@ -3,11 +3,13 @@
 
 #ifdef __XC__
 
+#if HID_CONTROLS > 0
 void UserHIDPoll();
 
 #define USER_MAIN_CORES on tile[XUD_TILE]: {\
                                         UserHIDPoll();\
                                     }
+#endif  // HID_CONTROLS > 0
 
 #endif
 


### PR DESCRIPTION
When compiling with HID_CONTROLS disabled, there is a linker warning that this function isn't defined - its definition is already in the same `HID_CONTROLS > 0` condition.