### PR TITLE
Parse junitxml files after tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,6 +121,9 @@ pipeline {
             }
           }
           post {
+            always {
+              junit "${REPO}/tests/pytest_result.xml"
+            }
             cleanup {
               xcoreCleanSandbox()
             }
@@ -172,6 +175,9 @@ pipeline {
             }
           }
           post {
+            always {
+              junit "${REPO}/tests/pytest_result.xml"
+            }
             cleanup {
               xcoreCleanSandbox()
             }


### PR DESCRIPTION
The "Tests" tab on Jenkins now shows the test output in a way that is easier to read.

I couldn't use the Jenkins shared library function `runPytest` for this change, because that requires installing pytest-xdist which we don't need because we only run one test at a time.

The test failures are all the expected failures that are currently being investigated on the S/PDIF configs.