### PR TITLE
Build documentation in parallel and correctly archive the output

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,55 +16,27 @@ pipeline {
     VIEW = getViewName(REPO)
   }
   stages {
-    stage('Create release and build') {
+    stage('Build') {
       agent {
         label '(linux || macOS) && x86_64'
       }
-      stages {
-        stage('Get view') {
-          steps {
-            xcorePrepareSandbox("${VIEW}", "${REPO}")
-          }
-        }
-        //stage('Create release') {
-        //  // This stage has to happen before everything else! It requires a clean
-        //  // sandbox
-        //  steps {
-        //    dir("${REPO}") {
-        //      viewEnv() {
-        //        runPython("python create_release.py --view ${VIEW}")
-        //      }
-        //    }
-        //  }
-        //}
-        stage('Build') {
-          steps {
-            viewEnv() {
-              dir("${REPO}") {
-                sh 'xmake -C app_usb_aud_xk_316_mc -j16 TEST_CONFIGS=1'
-                stash includes: 'app_usb_aud_xk_316_mc/bin/**/*.xe', name: 'xk_316_mc_bin', useDefaultExcludes: false
+      steps {
+        xcorePrepareSandbox("${VIEW}", "${REPO}")
+
+        viewEnv() {
+          dir("${REPO}") {
+            sh 'xmake -C app_usb_aud_xk_316_mc -j16 TEST_CONFIGS=1'
+            stash includes: 'app_usb_aud_xk_316_mc/bin/**/*.xe', name: 'xk_316_mc_bin', useDefaultExcludes: false
  
-                sh 'xmake -C app_usb_aud_xk_216_mc -j16 TEST_CONFIGS=1'
-                stash includes: 'app_usb_aud_xk_216_mc/bin/**/*.xe', name: 'xk_216_mc_bin', useDefaultExcludes: false
+            sh 'xmake -C app_usb_aud_xk_216_mc -j16 TEST_CONFIGS=1'
+            stash includes: 'app_usb_aud_xk_216_mc/bin/**/*.xe', name: 'xk_216_mc_bin', useDefaultExcludes: false
 
-                sh 'xmake -C app_usb_aud_xk_evk_xu316 -j16 TEST_CONFIGS=1'
-                stash includes: 'app_usb_aud_xk_evk_xu316/bin/**/*.xe', name: 'xk_evk_xu316_bin', useDefaultExcludes: false
-
-                dir("doc") {
-                  sh 'xdoc xmospdf'
-                  dir("_build/xlatex") {
-                    archiveArtifacts artifacts: "index.pdf", fingerprint: true, allowEmptyArchive: true
-                  }
-                }
-              }
-            }
+            sh 'xmake -C app_usb_aud_xk_evk_xu316 -j16 TEST_CONFIGS=1'
+            stash includes: 'app_usb_aud_xk_evk_xu316/bin/**/*.xe', name: 'xk_evk_xu316_bin', useDefaultExcludes: false
           }
         }
       }
       post {
-        always {
-          archiveArtifacts artifacts: "Release/*.zip", fingerprint: true, allowEmptyArchive: true
-        }
         cleanup {
           xcoreCleanSandbox()
         }
@@ -72,47 +44,60 @@ pipeline {
     }
     stage('Regression Test') {
       parallel {
+        stage('Documentation build') {
+          agent {
+            label '(linux || macOS) && x86_64'
+          }
+          steps {
+            xcorePrepareSandbox("${VIEW}", "${REPO}")
+            viewEnv() {
+              dir("${REPO}/doc") {
+                sh 'xdoc xmospdf'
+                archiveArtifacts artifacts: "pdf/*.pdf", fingerprint: true, allowEmptyArchive: false
+              }
+            }
+          }
+          post {
+            cleanup {
+              xcoreCleanSandbox()
+            }
+          }
+        }
         stage('MacOS Intel') {
           agent {
             label 'usb_audio && macos && x86_64 && xcore200-mcab && xcore.ai-explorer'
           }
-          stages {
-            stage('Get view') {
-              steps {
-                xcorePrepareSandbox("${VIEW}", "${REPO}")
-              }
+          steps {
+            xcorePrepareSandbox("${VIEW}", "${REPO}")
+
+            dir("${WORKSPACE}/sw_audio_analyzer") {
+              copyArtifacts filter: '**/*.xe', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+              copyArtifacts filter: 'host_xscope_controller/bin_macos/xscope_controller', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
             }
-            stage('Test') {
-              steps {
-                dir("${WORKSPACE}/sw_audio_analyzer") {
-                  copyArtifacts filter: '**/*.xe', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
-                  copyArtifacts filter: 'host_xscope_controller/bin_macos/xscope_controller', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+
+            dir("${REPO}") {
+              unstash 'xk_216_mc_bin'
+              unstash 'xk_evk_xu316_bin'
+              dir("tests") {
+                // Build test support application
+                sh 'make -C tools/volcontrol'
+
+                dir("tools") {
+                  copyArtifacts filter: 'bin_macos/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
                 }
-                dir("${REPO}") {
-                  unstash 'xk_216_mc_bin'
-                  unstash 'xk_evk_xu316_bin'
-                  dir("tests") {
-                    // Build test support application
-                    sh 'make -C tools/volcontrol'
 
-                    dir("tools") {
-                      copyArtifacts filter: 'bin_macos/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
-                    }
-
-                    viewEnv() {
-                      // The JENKINS env var is necessary for macOS catalina
-                      // We have to work around microphone permission issues
-                      // For more info, see the DevOps section of the XMOS wiki
-                      withEnv(["JENKINS=1"]) {
-                        withVenv() {
-                          sh "pip install -e ${WORKSPACE}/xtagctl"
-                          withXTAG(["usb_audio_mc_xs2_dut", "usb_audio_mc_xs2_harness", \
-                                    "usb_audio_xcai_exp_dut", "usb_audio_xcai_exp_harness"]) { xtagIds ->
-                            sh "pytest -m ${params.TEST_LEVEL} --junitxml=pytest_result.xml \
-                                -o xk_216_mc_dut=${xtagIds[0]} -o xk_216_mc_harness=${xtagIds[1]} \
-                                -o xk_evk_xu316_dut=${xtagIds[2]} -o xk_evk_xu316_harness=${xtagIds[3]}"
-                          }
-                        }
+                viewEnv() {
+                  // The JENKINS env var is necessary for macOS catalina
+                  // We have to work around microphone permission issues
+                  // For more info, see the DevOps section of the XMOS wiki
+                  withEnv(["JENKINS=1"]) {
+                    withVenv() {
+                      sh "pip install -e ${WORKSPACE}/xtagctl"
+                      withXTAG(["usb_audio_mc_xs2_dut", "usb_audio_mc_xs2_harness", \
+                                "usb_audio_xcai_exp_dut", "usb_audio_xcai_exp_harness"]) { xtagIds ->
+                        sh "pytest -m ${params.TEST_LEVEL} --junitxml=pytest_result.xml \
+                            -o xk_216_mc_dut=${xtagIds[0]} -o xk_216_mc_harness=${xtagIds[1]} \
+                            -o xk_evk_xu316_dut=${xtagIds[2]} -o xk_evk_xu316_harness=${xtagIds[3]}"
                       }
                     }
                   }
@@ -133,40 +118,34 @@ pipeline {
           agent {
             label 'usb_audio && macos && arm64 && xcore.ai-mcab'
           }
-          stages {
-            stage('Get view') {
-              steps {
-                xcorePrepareSandbox("${VIEW}", "${REPO}")
-              }
+          steps {
+            xcorePrepareSandbox("${VIEW}", "${REPO}")
+
+            dir("${WORKSPACE}/sw_audio_analyzer") {
+              copyArtifacts filter: '**/*.xe', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+              copyArtifacts filter: 'host_xscope_controller/bin_macos/xscope_controller', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
             }
-            stage('Test') {
-              steps {
-                dir("${WORKSPACE}/sw_audio_analyzer") {
-                  copyArtifacts filter: '**/*.xe', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
-                  copyArtifacts filter: 'host_xscope_controller/bin_macos/xscope_controller', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+
+            dir("${REPO}") {
+              unstash 'xk_316_mc_bin'
+              dir("tests") {
+                // Build test support application
+                sh 'make -C tools/volcontrol'
+
+                dir("tools") {
+                  copyArtifacts filter: 'bin_macos_m1/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
                 }
-                dir("${REPO}") {
-                  unstash 'xk_316_mc_bin'
-                  dir("tests") {
-                    // Build test support application
-                    sh 'make -C tools/volcontrol'
 
-                    dir("tools") {
-                      copyArtifacts filter: 'bin_macos_m1/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
-                    }
-
-                    viewEnv() {
-                      // The JENKINS env var is necessary for macOS catalina
-                      // We have to work around microphone permission issues
-                      // For more info, see the DevOps section of the XMOS wiki
-                      withEnv(["JENKINS=1"]) {
-                        withVenv() {
-                          sh "pip install -e ${WORKSPACE}/xtagctl"
-                          withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
-                            sh "pytest -m ${params.TEST_LEVEL} --junitxml=pytest_result.xml \
-                                -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]}"
-                          }
-                        }
+                viewEnv() {
+                  // The JENKINS env var is necessary for macOS catalina
+                  // We have to work around microphone permission issues
+                  // For more info, see the DevOps section of the XMOS wiki
+                  withEnv(["JENKINS=1"]) {
+                    withVenv() {
+                      sh "pip install -e ${WORKSPACE}/xtagctl"
+                      withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
+                        sh "pytest -m ${params.TEST_LEVEL} --junitxml=pytest_result.xml \
+                            -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]}"
                       }
                     }
                   }


### PR DESCRIPTION
(This turned into a much larger change than I expected, but it's mostly indentation)

Changes:
- moved the documentation build into its own parallel stage alongside the regression tests; this saves a couple of minutes as the docs don't need to be built before the tests begin
- correctly archive the PDF output from xdoc
- cleaned up some commented out code related to a release step we no longer perform, and removed the unnecessary archiveArtifacts
- merged the 'Get view' stages that just do xcorePrepareSandbox with the stage that does actual work; this makes the classic view clearer because there aren't loads of 'Get view' stages for the different parallel jobs in the regression (which would get worse when we add more runners for Windows testing)