### PR TITLE
app_usb_audio_316_mc: Set core power margin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,8 @@ UNRELEASED
 ----------
 
    * ADDED:     Build configs for synchronous mode (uses external CS2100 device)
-   * ADDED:     Build configs for xCORE as I2S slave in app_usb_aud_xk_316_mc
-
+   * ADDED:     app_usb_aud_xk_316_mc: Build configs for xCORE as I2S slave
+   * CHANGED:   app_usb_aud_xk_316_mc: Core voltage reduced to 0.9v (was 0.922v)
 
 7.0.0
 -----

--- a/app_usb_aud_xk_316_mc/src/extensions/audiohw.xc
+++ b/app_usb_aud_xk_316_mc/src/extensions/audiohw.xc
@@ -9,6 +9,14 @@
 on tile[0]: port p_scl = XS1_PORT_1L;
 on tile[0]: port p_sda = XS1_PORT_1M;
 on tile[0]: out port p_ctrl = XS1_PORT_8D;
+on tile[0]: in port p_margin = XS1_PORT_1G;  /* CORE_POWER_MARGIN:   Driven 0:   0.925v
+                                              *                      Pull down:  0.922v
+                                              *                      High-z:     0.9v
+                                              *                      Pull-up:    0.854v
+                                              *                      Driven 1:   0.85v
+                                              */
+
+
 
 #if (XUA_SPDIF_RX_EN || XUA_ADAT_RX_EN || (XUA_SYNCMODE == XUA_SYNCMODE_SYNC))
 /* If we have an external digital input interface or running in synchronous mode we need to use the 


### PR DESCRIPTION
Reduces xCORE core voltage from 0.922v to 0.9 using external circuitry on XK-AUDIO-316-MC