### PR TITLE
Parse app config with I2S disabled

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ board_configs = {}
 def parse_features(config):
     max_analogue_chans = 8
 
-    config_re = r"^(?P<uac>[12])(?P<sync_mode>[AS])(?P<slave>[MS])i(?P<chan_i>\d+)o(?P<chan_o>\d+)(?P<midi>[mx])(?P<spdif_i>[sx])(?P<spdif_o>[sx])(?P<adat_i>[ax])(?P<adat_o>[ax])(?P<dsd>[dx])(?P<tdm8>(_tdm8)?)"
+    config_re = r"^(?P<uac>[12])(?P<sync_mode>[AS])(?P<i2s>[MSX])i(?P<chan_i>\d+)o(?P<chan_o>\d+)(?P<midi>[mx])(?P<spdif_i>[sx])(?P<spdif_o>[sx])(?P<adat_i>[ax])(?P<adat_o>[ax])(?P<dsd>[dx])(?P<tdm8>(_tdm8)?)"
     match = re.search(config_re, config)
     if not match:
         pytest.exit(f"Unable to parse features from {config}")
@@ -44,8 +44,6 @@ def parse_features(config):
         features[k] = int(features[k])
     for k in ["midi", "spdif_i", "spdif_o", "adat_i", "adat_o", "dsd", "tdm8"]:
         features[k] = features[k] not in ["", "x"]
-
-    features["slave"] = features["slave"] == "S"
 
     # Set the number of analogue channels
     features["analogue_i"] = min(features["chan_i"], max_analogue_chans)

--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -119,7 +119,7 @@ def test_analogue_output(pytestconfig, xtag_wrapper, xsig, board_config, fs):
     xsig_config = f'mc_analogue_output_{features["analogue_o"]}ch'
     if "xk_316_mc" in board_config and features["tdm8"]:
         xsig_config = "mc_analogue_output_2ch"
-    elif "xk_216_mc" in board_config and features["tdm8"] and features["slave"]:
+    elif "xk_216_mc" in board_config and features["tdm8"] and features["i2s"] == "S":
         xsig_config += "_paired"  # Pairs of channels can be swapped in hardware
     xsig_config_path = Path(__file__).parent / "xsig_configs" / f"{xsig_config}.json"
     adapter_dut, adapter_harness = xtag_wrapper


### PR DESCRIPTION
Updated the app config regular expression to support I2S being disabled, rather than just master and slave modes.