### PR TITLE
Move TDM configs on xk_216_mc into build-testing only

### DIFF
--- a/app_usb_aud_xk_216_mc/Makefile
+++ b/app_usb_aud_xk_216_mc/Makefile
@@ -17,8 +17,8 @@ USED_MODULES = lib_xua lib_i2c
 # Build config naming scheme:
 
 # Audio Class:  1 or 2
-# Sync Mode             A(sync) or S(ync)
-# I2S                   M(aster) or S(lave)
+# Sync Mode             A(sync), S(ync) or (a)D(aptive)
+# I2S                   M(aster), S(lave) or X (I2S disabled)
 # Input                 enabled: i (channelcount)
 # Output                enabled: o (channelcount)
 # MIDI                  enabled: m, disabled: x
@@ -42,40 +42,21 @@ XCC_FLAGS_2AMi10o10xssxxx = $(BUILD_FLAGS) 		-DXUA_SPDIF_RX_EN=1 \
 												-DXUA_SPDIF_TX_EN=1
 
 # Audio Class 2, I2S Slave, 10xInput, 10xOutput, S/PDIF Rx, S/PDIF Tx
-INCLUDE_ONLY_IN_2AMi10o10xssxxx =
-XCC_FLAGS_2AMi10o10xssxxx = $(BUILD_FLAGS) 		-DXUA_SPDIF_RX_EN=1 \
+INCLUDE_ONLY_IN_2ASi10o10xssxxx =
+XCC_FLAGS_2ASi10o10xssxxx = $(BUILD_FLAGS) 		-DXUA_SPDIF_RX_EN=1 \
 												-DXUA_SPDIF_TX_EN=1 \
 												-DCODEC_MASTER=1
 
-# Audio Class 2, I2S Slave, 16xInput 16xOutput (TDM)
-INCLUDE_ONLY_IN_2ASi16o16xxxxxx_tdm8 = 
-XCC_FLAGS_2ASi16o16xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=16 \
-												-DI2S_CHANS_DAC=16 \
-												-DNUM_USB_CHAN_IN=16 \
-												-DNUM_USB_CHAN_OUT=16 \
-												-DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
-												-DMAX_FREQ=96000 \
-												-DCODEC_MASTER=1
-
-# Audio Class 2, I2S Master, 16xInput 16xOutput (TDM)
+# Audio Class 2, Async, I2S Slave, 16xInput 16xOutput (TDM)
 INCLUDE_ONLY_IN_2ASi16o16xxxxxx_tdm8 =
 XCC_FLAGS_2ASi16o16xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=16 \
-												-DI2S_CHANS_DAC=16 \
-												-DNUM_USB_CHAN_IN=16 \
-												-DNUM_USB_CHAN_OUT=16 \
-												-DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
-												-DMAX_FREQ=96000
+                                                                                                -DI2S_CHANS_DAC=16 \
+                                                                                                -DNUM_USB_CHAN_IN=16 \
+                                                                                                -DNUM_USB_CHAN_OUT=16 \
+                                                                                                -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
+                                                                                                -DMAX_FREQ=96000 \
+                                                                                                -DCODEC_MASTER=1
 
-# Audio Class 2, I2S Master, 32xInput 32xOutput, S/PDIF Tx (TDM)
-INCLUDE_ONLY_IN_2AMi32o32xxxxxx_tdm8 = 
-XCC_FLAGS_2AMi32o32xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=32 \
-												-DI2S_CHANS_DAC=32 \
-												-DNUM_USB_CHAN_IN=32 \
-												-DNUM_USB_CHAN_OUT=32 \
-												-DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
-												-DMAX_FREQ=48000 \
-												-DXUA_SPDIF_TX_EN=1 \
-												-DSPDIF_TX_INDEX=0
 
 ifneq ($(CONFIG),)
 BUILD_TEST_CONFIGS = 1

--- a/app_usb_aud_xk_216_mc/configs_build.inc
+++ b/app_usb_aud_xk_216_mc/configs_build.inc
@@ -7,6 +7,12 @@ XCC_FLAGS_1AMi8o2xxxxxx = $(BUILD_FLAGS) -DAUDIO_CLASS=1 \
                                          -DSTREAM_FORMAT_INPUT_1_RESOLUTION_BITS=16
 INCLUDE_ONLY_IN_1AMi8o2xxxxxx =
 
+# Audio Class 2, Async, I2S Master, No I2s Input, No I2S Output, S/PDIF Tx
+XCC_FLAGS_2AXi0o2xxsxxx = $(BUILD_FLAGS) -DXUA_SPDIF_TX_EN=1 \
+                                         -DI2S_CHANS_ADC=0 \
+                                         -DI2S_CHANS_DAC=0
+INCLUDE_ONLY_IN_2AXi0o2xxsxxx =
+
 # Audio Class 2, Async, I2S Master, 16xInput, 16xOutput, TDM
 # Note: sample rate restricted to 96K to fit in USB bandwidth
 XCC_FLAGS_2AMi16o16xxxxxx_tdm8  = $(BUILD_FLAGS) -DI2S_CHANS_DAC=16 \
@@ -32,11 +38,14 @@ XCC_FLAGS_2AMi32o32xxsxxx_tdm8 = $(BUILD_FLAGS) -DXUA_SPDIF_TX_EN=1 \
                                                 -DMAX_FREQ=48000
 INCLUDE_ONLY_IN_2AMi32o32xxsxxx_tdm8 =
 
-# Audio Class 2, Async, I2S Master, No I2s Input, No I2S Output, S/PDIF Tx
-XCC_FLAGS_2AMi0o2xxsxxx_noi2s = $(BUILD_FLAGS) -DXUA_SPDIF_TX_EN=1 \
-                                               -DI2S_CHANS_ADC=0 \
-                                               -DI2S_CHANS_DAC=0
-INCLUDE_ONLY_IN_2AMi0o2xxsxxx_noi2s =
+# Audio Class 2, Async, I2S Master, 32xInput 32xOutput (TDM)
+INCLUDE_ONLY_IN_2AMi32o32xxxxxx_tdm8 =
+XCC_FLAGS_2AMi32o32xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=32 \
+                                                -DI2S_CHANS_DAC=32 \
+                                                -DNUM_USB_CHAN_IN=32 \
+                                                -DNUM_USB_CHAN_OUT=32 \
+                                                -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
+                                                -DMAX_FREQ=48000
 
 # Audio Class 2, Async, I2S Slave, 0xInput, 8xOutput, TDM
 XCC_FLAGS_2ASi0o8xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=0 \
@@ -45,3 +54,27 @@ XCC_FLAGS_2ASi0o8xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=0 \
                                               -DCODEC_MASTER=1
 INCLUDE_ONLY_IN_2ASi0o8xxxxxx_tdm8 =
 
+# Audio Class 2, Async, I2S Master, 16xInput 16xOutput (TDM)
+INCLUDE_ONLY_IN_2AMi16o16xxxxxx_tdm8 =
+XCC_FLAGS_2AMi16o16xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=16 \
+                                                                                                -DI2S_CHANS_DAC=16 \
+                                                                                                -DNUM_USB_CHAN_IN=16 \
+                                                                                                -DNUM_USB_CHAN_OUT=16 \
+                                                                                                -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
+                                                                                                -DMAX_FREQ=96000
+
+# Audio Class 2, Async, I2S Master, 32xInput 32xOutput, S/PDIF Tx (TDM)
+INCLUDE_ONLY_IN_2AMi32o32xxsxxx_tdm8 =
+XCC_FLAGS_2AMi32o32xxsxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=32 \
+                                                                                                -DI2S_CHANS_DAC=32 \
+                                                                                                -DNUM_USB_CHAN_IN=32 \
+                                                                                                -DNUM_USB_CHAN_OUT=32 \
+                                                                                                -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
+                                                                                                -DMAX_FREQ=48000 \
+                                                                                                -DXUA_SPDIF_TX_EN=1 \
+                                                                                                -DSPDIF_TX_INDEX=0
+
+# Audio Class 2, Async, I2S Master, 8xInput 8xOutput (TDM)
+INCLUDE_ONLY_IN_2AMi8o8xxxxxx_tdm8 =
+XCC_FLAGS_2AMi8o8xxxxxx_tdm8 = $(BUILD_FLAGS)   -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
+                                                                                                -DMAX_FREQ=96000

--- a/app_usb_aud_xk_216_mc/configs_partial.inc
+++ b/app_usb_aud_xk_216_mc/configs_partial.inc
@@ -4,29 +4,15 @@
 XCC_FLAGS_2AMi8o8xxxxxx = $(BUILD_FLAGS)
 INCLUDE_ONLY_IN_2AMi8o8xxxxxx =
 
-# Audio Class 2, Async, I2S Master, 8xInput 8xOutput (TDM)
-INCLUDE_ONLY_IN_2AMi8o8xxxxxx_tdm8 =
-XCC_FLAGS_2AMi8o8xxxxxx_tdm8 = $(BUILD_FLAGS) 	-DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
-												-DMAX_FREQ=96000
-
 # Audio Class 2, Async, I2S Slave, 8xInput 8xOutput (TDM)
 INCLUDE_ONLY_IN_2ASi8o8xxxxxx_tdm8 =
-XCC_FLAGS_2ASi8o8xxxxxx_tdm8 = $(BUILD_FLAGS) 	-DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
-												-DMAX_FREQ=96000 \
-												-DCODEC_MASTER=1
+XCC_FLAGS_2ASi8o8xxxxxx_tdm8 = $(BUILD_FLAGS)   -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
+                                                                                                -DMAX_FREQ=96000 \
+                                                                                                -DCODEC_MASTER=1
 
- # Audio Class 2, Async, I2S Slave, 8xInput, 8xOutput
+# Audio Class 2, Async, I2S Slave, 8xInput, 8xOutput
 XCC_FLAGS_2ASi8o8xxxxxx = $(BUILD_FLAGS)        -DCODEC_MASTER=1
 INCLUDE_ONLY_IN_2ASi8o8xxxxxx =
-
-# Audio Class 2, Async, I2S Master, 32xInput 32xOutput (TDM)
-INCLUDE_ONLY_IN_2AMi32o32xxxxxx_tdm8 = 
-XCC_FLAGS_2AMi32o32xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=32 \
-												-DI2S_CHANS_DAC=32 \
-												-DNUM_USB_CHAN_IN=32 \
-												-DNUM_USB_CHAN_OUT=32 \
-												-DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
-												-DMAX_FREQ=48000
 
 # Audio Class 2, Async, I2S Master, 8xInput, 10xOutput, S/PDIF Tx
 XCC_FLAGS_2AMi8o10xxsxxx = $(BUILD_FLAGS)       -DXUA_SPDIF_TX_EN=1
@@ -37,33 +23,25 @@ INCLUDE_ONLY_IN_2AMi8o10mxsxxx =
 XCC_FLAGS_2AMi8o10mxsxxx = $(BUILD_FLAGS) 		-DMIDI=1 \
 												-DXUA_SPDIF_TX_EN=1
 
-# Audio Class 2, Async, I2S Master, 10xInput, 10xOutput, DSD
+# Audio Class 2, Async, I2S Master, 8xInput, 8xOutput, DSD
 INCLUDE_ONLY_IN_2AMi8o8xxxxxd =
 XCC_FLAGS_2AMi8o8xxxxxd = $(BUILD_FLAGS) 		-DDSD_CHANS_DAC=2
 
-# Audio Class 2, Async, I2S Master, 10xInput, 10xOutput, S/PDIF Tx (8 mixes)
+# Audio Class 2, Async, I2S Master, 8xInput, 10xOutput, S/PDIF Tx (8 mixes)
 INCLUDE_ONLY_IN_2AMi8o10xxsxxx_mix8 = 
 XCC_FLAGS_2AMi8o10xxsxxx_mix8 = $(BUILD_FLAGS)  -DXUA_SPDIF_TX_EN=1 \
 												-DMAX_MIX_COUNT=8
 
-# Audio Class 2, Async, I2S Master, 10xInput, 10xOutput, SPDIF Tx, DSD
-INCLUDE_ONLY_IN_2AMi8o10xssxxd =
-XCC_FLAGS_2AMi8o10xssxxd = $(BUILD_FLAGS) 		-DXUA_SPDIF_TX_EN=1 \
+# Audio Class 2, Async, I2S Master, 8xInput, 10xOutput, SPDIF Tx, DSD
+INCLUDE_ONLY_IN_2AMi8o10xxsxxd =
+XCC_FLAGS_2AMi8o10xxsxxd = $(BUILD_FLAGS) 		-DXUA_SPDIF_TX_EN=1 \
 												-DDSD_CHANS_DAC=2
 
-# Audio Class 2, Async, I2S Master, 16xInput, 10xOutput, ADAT Rx
-# Sample rate restriced to 96kHz fit in USB bandwidth
-INCLUDE_ONLY_IN_2Ai16o8xxxaxx =
-XCC_FLAGS_2Ai16o8xxxaxx = $(BUILD_FLAGS) 		-DXUA_ADAT_RX_EN=1 \
+# Audio Class 2, Async, I2S Master, 16xInput, 8xOutput, ADAT Rx
+# Sample rate restricted to 96kHz fit in USB bandwidth
+INCLUDE_ONLY_IN_2AMi16o8xxxaxx =
+XCC_FLAGS_2AMi16o8xxxaxx = $(BUILD_FLAGS) 		-DXUA_ADAT_RX_EN=1 \
 												-DMAX_FREQ=96000
-
-# Audio Class 2, Async, I2S Disabled, 0xInput, 2xOutput, S/PDIF Tx
-INCLUDE_ONLY_IN_2AXi0o2xxsxxx = 
-XCC_FLAGS_2AXi0o2xxsxxx = $(BUILD_FLAGS) 		-DXUA_SPDIF_TX_EN=1 \
-												-DI2S_CHANS_ADC=0 \
-												-DI2S_CHANS_DAC=0 \
-												-DNUM_USB_CHAN_IN=0 \
-												-DNUM_USB_CHAN_OUT=2
 
 # Audio Class 2, Sync, I2S Master, 8xInput, 8xOutput
 INCLUDE_ONLY_IN_2SMi8o8xxxxxx = 

--- a/app_usb_aud_xk_316_mc/Makefile
+++ b/app_usb_aud_xk_316_mc/Makefile
@@ -17,8 +17,8 @@ USED_MODULES = lib_xua lib_i2c
 # Build config naming scheme:
 #
 # Audio Class:   1 or 2
-# Sync Mode      A(sync) or S(ync)
-# I2S            M(aster) or S(lave)
+# Sync Mode             A(sync), S(ync) or (a)D(aptive)
+# I2S                   M(aster), S(lave) or X (I2S disabled)
 # Input          enabled: i (channelcount)
 # Output         enabled: o (channelcount)
 # MIDI           enabled: m, disabled: x

--- a/app_usb_aud_xk_316_mc/configs_partial.inc
+++ b/app_usb_aud_xk_316_mc/configs_partial.inc
@@ -46,7 +46,3 @@ XCC_FLAGS_2AMi16o8xxxaxx = $(BUILD_FLAGS) 		-DXUA_ADAT_RX_EN=1
 INCLUDE_ONLY_IN_2AMi8o16xxxxax =
 XCC_FLAGS_2AMi8o16xxxxax = $(BUILD_FLAGS) 		-DXUA_ADAT_TX_EN=1
 
-#
-# Synchronous Mode Configs
-#
-

--- a/app_usb_aud_xk_evk_xu316/Makefile
+++ b/app_usb_aud_xk_evk_xu316/Makefile
@@ -17,8 +17,8 @@ USED_MODULES = lib_xua lib_i2c
 # Build config naming scheme:
 
 # Audio Class:  1 or 2
-# Sync Mode     A(sync)/S(ync)
-# I2S           M(aster)/S(lave)
+# Sync Mode     A(sync), S(ync) or (a)D(aptive)
+# I2S           M(aster), S(lave) or X (I2S disabled)
 # Input         enabled: i (channelcount)
 # Output        enabled: o (channelcount)
 # MIDI          enabled: m, disabled: x

--- a/app_usb_aud_xk_evk_xu316_extrai2s/Makefile
+++ b/app_usb_aud_xk_evk_xu316_extrai2s/Makefile
@@ -17,16 +17,16 @@ USED_MODULES = lib_xud lib_xua lib_i2c lib_i2s
 # Build config naming scheme:
 
 # Audio Class:          1 or 2
-# Sync Mode             A(sync)/S(ync)
-# I2S                           M(aster)/S(lave)
-# Input                         enabled: i (channelcount)
-# Output                        enabled: o (channelcount)
-# MIDI                          enabled: m, disabled: x
-# SPDIF in                      enabled: s, disabled: x
-# SPDIF out                     enabled: s, disabled: x
-# ADAT in                       enabled: a, disabled: x
-# ADAT out                      enabled: a, disabled: x
-# DSD out                       enabled: d, disabled: x
+# Sync Mode             A(sync), S(ync) or (a)D(aptive)
+# I2S                   M(aster), S(lave) or X (I2S disabled)
+# Input                 enabled: i (channelcount)
+# Output                enabled: o (channelcount)
+# MIDI                  enabled: m, disabled: x
+# SPDIF in              enabled: s, disabled: x
+# SPDIF out             enabled: s, disabled: x
+# ADAT in               enabled: a, disabled: x
+# ADAT out              enabled: a, disabled: x
+# DSD out               enabled: d, disabled: x
 # e.g. 2AMi10o10xxsxxx: Audio class 2.0, Asynchronous, I2S Master, input and output enabled (10 channels each), no MIDI, SPDIF output, no SPDIF input, no ADAT
 # Configs that have only had their build process tested
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ board_configs = {}
 def parse_features(config):
     max_analogue_chans = 8
 
-    config_re = r"^(?P<uac>[12])(?P<sync_mode>[AS])(?P<i2s>[MSX])i(?P<chan_i>\d+)o(?P<chan_o>\d+)(?P<midi>[mx])(?P<spdif_i>[sx])(?P<spdif_o>[sx])(?P<adat_i>[ax])(?P<adat_o>[ax])(?P<dsd>[dx])(?P<tdm8>(_tdm8)?)"
+    config_re = r"^(?P<uac>[12])(?P<sync_mode>[ADS])(?P<i2s>[MSX])i(?P<chan_i>\d+)o(?P<chan_o>\d+)(?P<midi>[mx])(?P<spdif_i>[sx])(?P<spdif_o>[sx])(?P<adat_i>[ax])(?P<adat_o>[ax])(?P<dsd>[dx])(?P<tdm8>(_tdm8)?)"
     match = re.search(config_re, config)
     if not match:
         pytest.exit(f"Error: Unable to parse features from {config}")

--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -57,8 +57,8 @@ def analogue_duration(level, partial):
 
 
 @pytest.mark.uncollect_if(func=analogue_input_uncollect)
-@pytest.mark.parametrize("board_config", list_configs())
 @pytest.mark.parametrize("fs", samp_freqs)
+@pytest.mark.parametrize("board_config", list_configs())
 def test_analogue_input(pytestconfig, xtag_wrapper, xsig, board_config, fs):
     features = get_config_features(board_config)
     xsig_config = f'mc_analogue_input_{features["analogue_i"]}ch'
@@ -112,8 +112,8 @@ def test_analogue_input(pytestconfig, xtag_wrapper, xsig, board_config, fs):
 
 
 @pytest.mark.uncollect_if(func=analogue_output_uncollect)
-@pytest.mark.parametrize("board_config", list_configs())
 @pytest.mark.parametrize("fs", samp_freqs)
+@pytest.mark.parametrize("board_config", list_configs())
 def test_analogue_output(pytestconfig, xtag_wrapper, xsig, board_config, fs):
     features = get_config_features(board_config)
     xsig_config = f'mc_analogue_output_{features["analogue_o"]}ch'

--- a/tests/test_spdif.py
+++ b/tests/test_spdif.py
@@ -47,8 +47,8 @@ def spdif_duration(level, partial):
 
 
 @pytest.mark.uncollect_if(func=spdif_input_uncollect)
-@pytest.mark.parametrize("board_config", list_configs())
 @pytest.mark.parametrize("fs", samp_freqs)
+@pytest.mark.parametrize("board_config", list_configs())
 def test_spdif_input(pytestconfig, xtag_wrapper, xsig, board_config, fs):
     features = get_config_features(board_config)
     xsig_config = f'mc_digital_input_{features["analogue_i"]}ch'
@@ -119,8 +119,8 @@ def test_spdif_input(pytestconfig, xtag_wrapper, xsig, board_config, fs):
 
 
 @pytest.mark.uncollect_if(func=spdif_output_uncollect)
-@pytest.mark.parametrize("board_config", list_configs())
 @pytest.mark.parametrize("fs", samp_freqs)
+@pytest.mark.parametrize("board_config", list_configs())
 def test_spdif_output(pytestconfig, xtag_wrapper, xsig, board_config, fs):
     features = get_config_features(board_config)
     xsig_config = f'mc_digital_output_{features["analogue_o"]}ch'


### PR DESCRIPTION
- Moved all TDM configs on the xk_216_mc into build-testing only due to #99 
- Also tidied some errors in the config names.
- The `2AXi0o2xxsxxx` config asserts on startup (#95) so I've moved it to the build-only configs.
- Minor change in some of the test scripts: reversing the order of the pytest parametrize commands makes the produced list easier to read by grouping on the config name rather than sample rate.