### PR TITLE
Add Windows analogue testing using built-in driver

### DIFF
--- a/app_usb_aud_xk_316_mc/configs_test.inc
+++ b/app_usb_aud_xk_316_mc/configs_test.inc
@@ -4,3 +4,5 @@
 XCC_FLAGS_upgrade1 = $(BUILD_FLAGS) -DBCD_DEVICE_J=0x99 -DBCD_DEVICE_M=0x0 -DBCD_DEVICE_N=0x1
 XCC_FLAGS_upgrade2 = $(BUILD_FLAGS) -DBCD_DEVICE_J=0x99 -DBCD_DEVICE_M=0x0 -DBCD_DEVICE_N=0x2
 
+# Windows testing with the built-in driver relies on using product IDs that the Thesycon driver won't bind to
+XCC_FLAGS_2AMi8o8xxxxxx_winbuiltin = $(BUILD_FLAGS) -DPID_AUDIO_2=0x001a

--- a/app_usb_aud_xk_316_mc/src/core/xua_conf.h
+++ b/app_usb_aud_xk_316_mc/src/core/xua_conf.h
@@ -131,8 +131,12 @@
 
 /*** Defines relating to USB descriptor strings and ID's ***/
 #define VENDOR_ID          (0x20B1) /* XMOS VID */
+#ifndef PID_AUDIO_2
 #define PID_AUDIO_2        (0x0016)
+#endif
+#ifndef PID_AUDIO_1
 #define PID_AUDIO_1        (0x0017)
+#endif
 #define PRODUCT_STR_A2     "XMOS xCORE.ai MC (UAC2.0)"
 #define PRODUCT_STR_A1     "XMOS xCORE.ai MC (UAC1.0)"
 

--- a/tests/test_dfu.py
+++ b/tests/test_dfu.py
@@ -103,6 +103,9 @@ dfu_testcases = [
 
 
 def dfu_uncollect(pytestconfig, board, config):
+    # Not yet supported on Windows
+    if platform.system() == "Windows":
+        return True
     level = pytestconfig.getoption("level")
     if level == "smoke":
         return board in ["xk_216_mc", "xk_evk_xu316"]

--- a/tests/test_spdif.py
+++ b/tests/test_spdif.py
@@ -4,6 +4,7 @@ import pytest
 import subprocess
 import time
 import json
+import platform
 
 from usb_audio_test_utils import (
     check_analyzer_output,
@@ -23,7 +24,7 @@ class SpdifClockSrc:
     def __enter__(self):
         subprocess.run([self.volcontrol, "--clock", "SPDIF"], timeout=10)
         # Short delay to wait for clock source
-        time.sleep(1)
+        time.sleep(3)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -45,6 +46,9 @@ def spdif_common_uncollect(fs, features, board, pytestconfig):
 
 
 def spdif_input_uncollect(pytestconfig, board, config, fs):
+    # Not yet supported on Windows
+    if platform.system() == "Windows":
+        return True
     features = get_config_features(board, config)
     return any([not features["spdif_i"], spdif_common_uncollect(fs, features, board, pytestconfig)])
 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -5,6 +5,7 @@ import time
 import json
 import subprocess
 import tempfile
+import platform
 
 from usb_audio_test_utils import (
     check_analyzer_output,
@@ -48,6 +49,9 @@ volume_configs = [
 
 
 def volume_uncollect(pytestconfig, board, config, fs, channel):
+    # Not yet supported on Windows
+    if platform.system() == "Windows":
+        return True
     xtag_ids = get_xtag_dut_and_harness(pytestconfig, board)
     # XTAGs not present
     if not all(xtag_ids):


### PR DESCRIPTION
Add test automation on Windows for analogue input, analogue output and S/PDIF output tests. The same configs are run as for the Mac agents (with a reduced set for the Windows smoke level to avoid a really long duration), but there is an additional config in the test-support configs called `2AMi8o8xxxxxx_winbuiltin` which has a different PID to avoid using the Thesycon driver. (The UAC1 configs also use the builtin driver at the moment as their PID wasn't added to the Thesycon driver, but when that changes, an `_winbuiltin` config could be added for UAC1).

Making these tests run consistently with the unsolved issues around XTAG reliability was the challenge here: in general, everything needed to slow down a bit, so I've added/increased some of the sleeps in the tests. Also we now always connect via xgdb to the analyzer to make sure it has stopped - this will also trigger a reboot of the XTAG when it gets stuck, so it needs a long timeout.