### PR TITLE
Refactor Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,29 +20,46 @@ pipeline {
       agent {
         label '(linux || macOS) && x86_64'
       }
-      steps {
-        xcorePrepareSandbox("${VIEW}", "${REPO}")
+      stages {
+        stage('Get view') {
+          steps {
+            xcorePrepareSandbox("${VIEW}", "${REPO}")
+          }
+        }
+        stage('Build applications') {
+          steps {
+            viewEnv() {
+              dir("${REPO}") {
+                // Build and archive the main app configs; doing each app separately is faster than xmake in top directory
+                sh 'xmake -C app_usb_aud_xk_316_mc -j16'
+                sh 'xmake -C app_usb_aud_xk_216_mc -j16'
+                sh 'xmake -C app_usb_aud_xk_evk_xu316 -j16'
+                archiveArtifacts artifacts: "app_usb_aud_*/bin/**/*.xe", fingerprint: true, allowEmptyArchive: false
 
-        viewEnv() {
-          dir("${REPO}") {
-            // Build and archive the main app configs; doing each app separately is faster than xmake in top directory
-            sh 'xmake -C app_usb_aud_xk_316_mc -j16'
-            sh 'xmake -C app_usb_aud_xk_216_mc -j16'
-            sh 'xmake -C app_usb_aud_xk_evk_xu316 -j16'
-            archiveArtifacts artifacts: "app_usb_aud_*/bin/**/*.xe", fingerprint: true, allowEmptyArchive: false
+                // Build all other configs for testing and stash for stages on the later agents
+                sh 'xmake -C app_usb_aud_xk_316_mc -j16 BUILD_TEST_CONFIGS=1 TEST_SUPPORT_CONFIGS=1'
+                stash includes: 'app_usb_aud_xk_316_mc/bin/**/*.xe', name: 'xk_316_mc_bin', useDefaultExcludes: false
 
-            // Build all other configs for testing and stash for stages on the later agents
-            sh 'xmake -C app_usb_aud_xk_316_mc -j16 BUILD_TEST_CONFIGS=1 TEST_SUPPORT_CONFIGS=1'
-            stash includes: 'app_usb_aud_xk_316_mc/bin/**/*.xe', name: 'xk_316_mc_bin', useDefaultExcludes: false
+                sh 'xmake -C app_usb_aud_xk_216_mc -j16 BUILD_TEST_CONFIGS=1 TEST_SUPPORT_CONFIGS=1'
+                stash includes: 'app_usb_aud_xk_216_mc/bin/**/*.xe', name: 'xk_216_mc_bin', useDefaultExcludes: false
 
-            sh 'xmake -C app_usb_aud_xk_216_mc -j16 BUILD_TEST_CONFIGS=1 TEST_SUPPORT_CONFIGS=1'
-            stash includes: 'app_usb_aud_xk_216_mc/bin/**/*.xe', name: 'xk_216_mc_bin', useDefaultExcludes: false
+                sh 'xmake -C app_usb_aud_xk_evk_xu316 -j16 BUILD_TEST_CONFIGS=1 TEST_SUPPORT_CONFIGS=1'
+                stash includes: 'app_usb_aud_xk_evk_xu316/bin/**/*.xe', name: 'xk_evk_xu316_bin', useDefaultExcludes: false
 
-            sh 'xmake -C app_usb_aud_xk_evk_xu316 -j16 BUILD_TEST_CONFIGS=1 TEST_SUPPORT_CONFIGS=1'
-            stash includes: 'app_usb_aud_xk_evk_xu316/bin/**/*.xe', name: 'xk_evk_xu316_bin', useDefaultExcludes: false
-
-            // Build untested app
-            sh 'xmake -C app_usb_aud_xk_evk_xu316_extrai2s -j16'
+                // Build untested app
+                sh 'xmake -C app_usb_aud_xk_evk_xu316_extrai2s -j16'
+              }
+            }
+          }
+        }
+        stage('Build documentation') {
+          steps {
+            viewEnv() {
+              dir("${REPO}/doc") {
+                sh 'xdoc xmospdf'
+                archiveArtifacts artifacts: "pdf/*.pdf", fingerprint: true, allowEmptyArchive: false
+              }
+            }
           }
         }
       }
@@ -54,60 +71,55 @@ pipeline {
     }
     stage('Regression Test') {
       parallel {
-        stage('Documentation build') {
-          agent {
-            label '(linux || macOS) && x86_64'
-          }
-          steps {
-            xcorePrepareSandbox("${VIEW}", "${REPO}")
-            viewEnv() {
-              dir("${REPO}/doc") {
-                sh 'xdoc xmospdf'
-                archiveArtifacts artifacts: "pdf/*.pdf", fingerprint: true, allowEmptyArchive: false
-              }
-            }
-          }
-          post {
-            cleanup {
-              xcoreCleanSandbox()
-            }
-          }
-        }
         stage('MacOS Intel') {
           agent {
             label 'usb_audio && macos && x86_64 && xcore200-mcab && xcore.ai-explorer'
           }
-          steps {
-            xcorePrepareSandbox("${VIEW}", "${REPO}")
-
-            dir("${WORKSPACE}/sw_audio_analyzer") {
-              copyArtifacts filter: '**/*.xe', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
-              copyArtifacts filter: 'host_xscope_controller/bin_macos/xscope_controller', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+          stages {
+            stage('Get view') {
+              steps {
+                xcorePrepareSandbox("${VIEW}", "${REPO}")
+              }
             }
-
-            dir("${REPO}") {
-              unstash 'xk_216_mc_bin'
-              unstash 'xk_evk_xu316_bin'
-              dir("tests") {
-                // Build test support application
-                sh 'make -C tools/volcontrol'
-
-                dir("tools") {
-                  copyArtifacts filter: 'bin_macos/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
+            stage('Setup') {
+              steps {
+                dir("${WORKSPACE}/sw_audio_analyzer") {
+                  copyArtifacts filter: '**/*.xe', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+                  copyArtifacts filter: 'host_xscope_controller/bin_macos/xscope_controller', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
                 }
 
-                viewEnv() {
-                  // The JENKINS env var is necessary for macOS catalina
-                  // We have to work around microphone permission issues
-                  // For more info, see the DevOps section of the XMOS wiki
-                  withEnv(["JENKINS=1"]) {
+                dir("${REPO}") {
+                  unstash 'xk_216_mc_bin'
+                  unstash 'xk_evk_xu316_bin'
+                  dir("tests") {
                     withVenv() {
                       sh "pip install -e ${WORKSPACE}/xtagctl"
-                      withXTAG(["usb_audio_mc_xs2_dut", "usb_audio_mc_xs2_harness", \
-                                "usb_audio_xcai_exp_dut", "usb_audio_xcai_exp_harness"]) { xtagIds ->
-                        sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_intel.xml \
-                            -o xk_216_mc_dut=${xtagIds[0]} -o xk_216_mc_harness=${xtagIds[1]} \
-                            -o xk_evk_xu316_dut=${xtagIds[2]} -o xk_evk_xu316_harness=${xtagIds[3]}"
+                    }
+
+                    dir("tools") {
+                      // Build test support application
+                      sh 'make -C volcontrol'
+                      copyArtifacts filter: 'bin_macos/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
+                    }
+                  }
+                }
+              }
+            }
+            stage('Test') {
+              steps {
+                dir("${REPO}/tests") {
+                  viewEnv() {
+                    // The JENKINS env var is necessary for macOS catalina
+                    // We have to work around microphone permission issues
+                    // For more info, see the DevOps section of the XMOS wiki
+                    withEnv(["JENKINS=1"]) {
+                      withVenv() {
+                        withXTAG(["usb_audio_mc_xs2_dut", "usb_audio_mc_xs2_harness", \
+                                  "usb_audio_xcai_exp_dut", "usb_audio_xcai_exp_harness"]) { xtagIds ->
+                          sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_intel.xml \
+                              -o xk_216_mc_dut=${xtagIds[0]} -o xk_216_mc_harness=${xtagIds[1]} \
+                              -o xk_evk_xu316_dut=${xtagIds[2]} -o xk_evk_xu316_harness=${xtagIds[3]}"
+                        }
                       }
                     }
                   }
@@ -129,34 +141,48 @@ pipeline {
           agent {
             label 'usb_audio && macos && arm64 && xcore.ai-mcab'
           }
-          steps {
-            xcorePrepareSandbox("${VIEW}", "${REPO}")
-
-            dir("${WORKSPACE}/sw_audio_analyzer") {
-              copyArtifacts filter: '**/*.xe', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
-              copyArtifacts filter: 'host_xscope_controller/bin_macos/xscope_controller', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+          stages {
+            stage('Get view') {
+              steps {
+                xcorePrepareSandbox("${VIEW}", "${REPO}")
+              }
             }
-
-            dir("${REPO}") {
-              unstash 'xk_316_mc_bin'
-              dir("tests") {
-                // Build test support application
-                sh 'make -C tools/volcontrol'
-
-                dir("tools") {
-                  copyArtifacts filter: 'bin_macos_m1/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
+            stage('Setup') {
+              steps {
+                dir("${WORKSPACE}/sw_audio_analyzer") {
+                  copyArtifacts filter: '**/*.xe', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
+                  copyArtifacts filter: 'host_xscope_controller/bin_macos/xscope_controller', fingerprintArtifacts: true, projectName: 'xmos-int/sw_audio_analyzer/master', selector: lastSuccessful()
                 }
 
-                viewEnv() {
-                  // The JENKINS env var is necessary for macOS catalina
-                  // We have to work around microphone permission issues
-                  // For more info, see the DevOps section of the XMOS wiki
-                  withEnv(["JENKINS=1"]) {
+                dir("${REPO}") {
+                  unstash 'xk_316_mc_bin'
+                  dir("tests") {
                     withVenv() {
                       sh "pip install -e ${WORKSPACE}/xtagctl"
-                      withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
-                        sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_arm.xml \
-                            -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]}"
+                    }
+
+                    dir("tools") {
+                      // Build test support application
+                      sh 'make -C volcontrol'
+                      copyArtifacts filter: 'bin_macos_m1/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
+                    }
+                  }
+                }
+              }
+            }
+            stage('Test') {
+              steps {
+                dir("${REPO}/tests") {
+                  viewEnv() {
+                    // The JENKINS env var is necessary for macOS catalina
+                    // We have to work around microphone permission issues
+                    // For more info, see the DevOps section of the XMOS wiki
+                    withEnv(["JENKINS=1"]) {
+                      withVenv() {
+                        withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
+                          sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_arm.xml \
+                              -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]}"
+                        }
                       }
                     }
                   }
@@ -185,7 +211,7 @@ pipeline {
       }
       post {
         cleanup {
-          cleanWs()
+          xcoreCleanSandbox()
         }
       }
     }


### PR DESCRIPTION
Combining the Jenkins job steps into fewer stages was a mistake as logs weren't being displayed in the BlueOcean and Classic views for all the commands being run because of [this issue](https://github.com/xmos/xmos_jenkins_shared_library/issues/313). Splitting the large stages into smaller ones avoids this problem. Also moved the documentation build back into the first stage with the application builds, since this makes more sense and it doesn't take long to run in relation to the whole job.