### PR TITLE
Change AppPLL settings to reduce jitter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ sw_usb_audio Change Log
 UNRELEASED
 ----------
 
+  * CHANGED:   AppPLL settings to reduce jitter (#112)
   * FIXED:     Configuration of DACs when changing sample rate (#110)
 
 7.1.0

--- a/shared/apppll.h
+++ b/shared/apppll.h
@@ -1,81 +1,96 @@
 #include <platform.h>
 #include <stdint.h>
 
-// App PLL setup
-#define APP_PLL_CTL_BYPASS       (0)   // 0 = no bypass, 1 = bypass.
-#define APP_PLL_CTL_INPUT_SEL    (0)   // 0 = XTAL, 1 = sysPLL
-#define APP_PLL_CTL_ENABLE       (1)   // 0 = disabled, 1 = enabled.
+//Found solution: IN 24.000MHz, OUT 49.151786MHz, VCO 3145.71MHz, RD 1, FD 131.071 (m = 1, n = 14), OD 8, FOD 2, ERR -4.36ppm
+// Measure: 100Hz-40kHz: ~7ps
+// 100Hz-1MHz: 70ps.
+// 100Hz high pass: 118ps.
+#define APP_PLL_CTL_49M  0x0B808200
+#define APP_PLL_DIV_49M  0x80000001
+#define APP_PLL_FRAC_49M 0x8000000D
 
-// 24MHz in, 24.576MHz out, integer mode
-// Found exact solution:   IN  24000000.0, OUT  24576000.0, VCO 2457600000.0, RD  5, FD  512, OD 10, FOD  10
-#define APP_PLL_CTL_OD_48        (4)   // Output divider = (OD+1)
-#define APP_PLL_CTL_F_48         (511) // FB divider = (F+1)/2
-#define APP_PLL_CTL_R_48         (4)   // Ref divider = (R+1)
+//Found solution: IN 24.000MHz, OUT 45.157895MHz, VCO 2709.47MHz, RD 1, FD 112.895 (m = 17, n = 19), OD 5, FOD 3, ERR -11.19ppm
+// Measure: 100Hz-40kHz: 6.5ps
+// 100Hz-1MHz: 67ps.
+// 100Hz high pass: 215ps.
+#define APP_PLL_CTL_45M  0x0A006F00
+#define APP_PLL_DIV_45M  0x80000002
+#define APP_PLL_FRAC_45M 0x80001012
 
-#define APP_PLL_CTL_48           ((APP_PLL_CTL_BYPASS << 29) | (APP_PLL_CTL_INPUT_SEL << 28) | (APP_PLL_CTL_ENABLE << 27) |\
-                                    (APP_PLL_CTL_OD_48 << 23) | (APP_PLL_CTL_F_48 << 8) | APP_PLL_CTL_R_48)
+// Found solution: IN 24.000MHz, OUT 24.576000MHz, VCO 2457.60MHz, RD 1, FD 102.400 (m = 2, n = 5), OD 5, FOD 5, ERR 0.0ppm
+// Measure: 100Hz-40kHz: ~8ps
+// 100Hz-1MHz: 63ps.
+// 100Hz high pass: 127ps.
+#define APP_PLL_CTL_24M  0x0A006500
+#define APP_PLL_DIV_24M  0x80000004
+#define APP_PLL_FRAC_24M 0x80000104
 
-// Fractional divide is M/N
-#define APP_PLL_FRAC_EN_48             (0)   // 0 = disabled
-#define APP_PLL_FRAC_NPLUS1_CYCLES_48  (0)   // M value is this reg value + 1.
-#define APP_PLL_FRAC_TOTAL_CYCLES_48   (0)   // N value is this reg value + 1.
-#define APP_PLL_FRAC_48          ((APP_PLL_FRAC_EN_48 << 31) | (APP_PLL_FRAC_NPLUS1_CYCLES_48 << 8) | APP_PLL_FRAC_TOTAL_CYCLES_48)
+// Found solution: IN 24.000MHz, OUT 22.579186MHz, VCO 3522.35MHz, RD 1, FD 146.765 (m = 13, n = 17), OD 3, FOD 13, ERR -0.641ppm
+// Measure: 100Hz-40kHz: 7ps
+// 100Hz-1MHz: 67ps.
+// 100Hz high pass: 260ps.
+#define APP_PLL_CTL_22M  0x09009100
+#define APP_PLL_DIV_22M  0x8000000C
+#define APP_PLL_FRAC_22M 0x80000C10
 
-// 24MHz in, 22.5792MHz out (44.1kHz * 512), frac mode
-// Found exact solution:   IN  24000000.0, OUT  22579200.0, VCO 2257920000.0, RD  5, FD  470.400 (m =   2, n =   5), OD  5, FOD   10
-#define APP_PLL_CTL_OD_441       (4)   // Output divider = (OD+1)
-#define APP_PLL_CTL_F_441        (469) // FB divider = (F+1)/2
-#define APP_PLL_CTL_R_441        (4)   // Ref divider = (R+1)
 
-#define APP_PLL_CTL_441          ((APP_PLL_CTL_BYPASS << 29) | (APP_PLL_CTL_INPUT_SEL << 28) | (APP_PLL_CTL_ENABLE << 27) |\
-                                    (APP_PLL_CTL_OD_441 << 23) | (APP_PLL_CTL_F_441 << 8) | APP_PLL_CTL_R_441)
+#define APP_PLL_CTL_ENABLE (1 << 27)
+#define APP_PLL_CLK_OUTPUT_ENABLE (1 << 16)
 
-#define APP_PLL_FRAC_EN_44             (1)   // 1 = enabled
-#define APP_PLL_FRAC_NPLUS1_CYCLES_44  (1)   // M value is this reg value + 1.
-#define APP_PLL_FRAC_TOTAL_CYCLES_44   (4)   // N value is this reg value + 1.define APP_PLL_CTL_R_441        (4)   // Ref divider = (R+1)
-#define APP_PLL_FRAC_44   ((APP_PLL_FRAC_EN_44 << 31) | (APP_PLL_FRAC_NPLUS1_CYCLES_44 << 8) | APP_PLL_FRAC_TOTAL_CYCLES_44)
-
-#define APP_PLL_DIV_INPUT_SEL    (1)   // 0 = sysPLL, 1 = app_PLL
-#define APP_PLL_DIV_DISABLE      (0)   // 1 = disabled (pin connected to X1D11), 0 = enabled divider output to pin.
-#define APP_PLL_DIV_VALUE        (4)   // Divide by N+1 - remember there's a /2 also afterwards for 50/50 duty cycle.
-#define APP_PLL_DIV              ((APP_PLL_DIV_INPUT_SEL << 31) | (APP_PLL_DIV_DISABLE << 16) | APP_PLL_DIV_VALUE)
 
 /* TODO support more than two freqs..*/
 int AppPllEnable(int32_t clkFreq_hz)
 {
+    // Ensure the AppPLL is enabled
+    unsigned data;
+    read_node_config_reg(tile[0], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, data);
+    write_node_config_reg(tile[0], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, data | APP_PLL_CTL_ENABLE);
+
+    // Turn off the clock output
+    read_node_config_reg(tile[0], XS1_SSWITCH_SS_APP_CLK_DIVIDER_NUM, data);
+    write_node_config_reg(tile[0], XS1_SSWITCH_SS_APP_CLK_DIVIDER_NUM, data | APP_PLL_CLK_OUTPUT_ENABLE);
+
     switch(clkFreq_hz)
     {
         case 44100*512:
 
             // Disable the PLL
-            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, (APP_PLL_CTL_441 & 0xF7FFFFFF));
+            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, (APP_PLL_CTL_22M & 0xF7FFFFFF));
             // Enable the PLL to invoke a reset on the appPLL.
-            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_441);
+            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_22M);
             // Must write the CTL register twice so that the F and R divider values are captured using a running clock.
-            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_441);
+            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_22M);
             // Now disable and re-enable the PLL so we get the full 5us reset time with the correct F and R values.
-            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, (APP_PLL_CTL_441 & 0xF7FFFFFF));
-            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_441);
-
+            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, (APP_PLL_CTL_22M & 0xF7FFFFFF));
+            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_22M);
+            delay_microseconds(500);
             // Set the fractional divider if used
-            write_node_config_reg(tile[0], XS1_SSWITCH_SS_APP_PLL_FRAC_N_DIVIDER_NUM, APP_PLL_FRAC_44);
+            write_node_config_reg(tile[0], XS1_SSWITCH_SS_APP_PLL_FRAC_N_DIVIDER_NUM, APP_PLL_FRAC_22M);
+            // Wait for PLL output frequency to stabilise due to fractional divider enable
+            delay_microseconds(100);
+            // Turn on the clock output
+            write_node_config_reg(tile[0], XS1_SSWITCH_SS_APP_CLK_DIVIDER_NUM, APP_PLL_DIV_22M);
 
             break;
 
         case 48000*512:
 
             // Disable the PLL
-            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, (APP_PLL_CTL_48 & 0xF7FFFFFF));
+            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, (APP_PLL_CTL_24M & 0xF7FFFFFF));
             // Enable the PLL to invoke a reset on the appPLL.
-            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_48);
+            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_24M);
             // Must write the CTL register twice so that the F and R divider values are captured using a running clock.
-            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_48);
+            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_24M);
             // Now disable and re-enable the PLL so we get the full 5us reset time with the correct F and R values.
-            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, (APP_PLL_CTL_48 & 0xF7FFFFFF));
-            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_48);
-
+            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, (APP_PLL_CTL_24M & 0xF7FFFFFF));
+            write_node_config_reg(tile[1], XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_24M);
+            delay_microseconds(500);
             // Set the fractional divider if used
-            write_node_config_reg(tile[0], XS1_SSWITCH_SS_APP_PLL_FRAC_N_DIVIDER_NUM, APP_PLL_FRAC_48);
+            write_node_config_reg(tile[0], XS1_SSWITCH_SS_APP_PLL_FRAC_N_DIVIDER_NUM, APP_PLL_FRAC_24M);
+            // Wait for PLL output frequency to stabilise due to fractional divider enable
+            delay_microseconds(100);
+            // Turn on the clock output
+            write_node_config_reg(tile[0], XS1_SSWITCH_SS_APP_CLK_DIVIDER_NUM, APP_PLL_DIV_24M);
 
             break;
 
@@ -83,12 +98,6 @@ int AppPllEnable(int32_t clkFreq_hz)
             assert(0);
             break;
     }
-
-    // Wait for PLL output frequency to stabilise due to fractional divider enable
-    delay_microseconds(100);
-
-    // Turn on the clock output
-    write_node_config_reg(tile[0], XS1_SSWITCH_SS_APP_CLK_DIVIDER_NUM, APP_PLL_DIV);
 
 	return 0;
 }


### PR DESCRIPTION
Fixes #112 

Applied the AppPLL settings from #112, so we now have values for 45.1584MHz and 49.152MHz. I replaced the `_441` and `_48` in the defined names to have suffixes representing the AppPLL frequency, but other suggestions are welcome for the naming!

Also now turn off the output from the AppPLL before changing the settings, and add a missing 500us delay.