### PR TITLE
Test improvements to improve stability, particularly on error handling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,10 +109,7 @@ pipeline {
               steps {
                 dir("${REPO}/tests") {
                   viewEnv() {
-                    // The JENKINS env var is necessary for macOS catalina
-                    // We have to work around microphone permission issues
-                    // For more info, see the DevOps section of the XMOS wiki
-                    withEnv(["JENKINS=1"]) {
+                    withEnv(["USBA_MAC_PRIV_WORKAROUND=1"]) {
                       withVenv() {
                         withXTAG(["usb_audio_mc_xs2_dut", "usb_audio_mc_xs2_harness", \
                                   "usb_audio_xcai_exp_dut", "usb_audio_xcai_exp_harness"]) { xtagIds ->
@@ -174,10 +171,7 @@ pipeline {
               steps {
                 dir("${REPO}/tests") {
                   viewEnv() {
-                    // The JENKINS env var is necessary for macOS catalina
-                    // We have to work around microphone permission issues
-                    // For more info, see the DevOps section of the XMOS wiki
-                    withEnv(["JENKINS=1"]) {
+                    withEnv(["USBA_MAC_PRIV_WORKAROUND=1"]) {
                       withVenv() {
                         withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
                           sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_arm.xml \

--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -1,19 +1,16 @@
 # Copyright (c) 2020-2022, XMOS Ltd, All rights reserved
-import io
 from pathlib import Path
 import pytest
-import subprocess
 import time
 import json
-import tempfile
-import signal
 
 from usb_audio_test_utils import (
-    wait_for_portaudio,
-    get_firmware_path_harness,
-    get_firmware_path,
-    run_audio_command,
     check_analyzer_output,
+    get_xtag_dut_and_harness,
+    AudioAnalyzerHarness,
+    XrunDut,
+    XsigInput,
+    XsigOutput,
 )
 from conftest import list_configs, get_config_features
 
@@ -21,14 +18,20 @@ from conftest import list_configs, get_config_features
 samp_freqs = [44100, 48000, 88200, 96000, 176400, 192000]
 
 
-def analogue_common_uncollect(fs, features):
+def analogue_common_uncollect(fs, features, board, pytestconfig):
     # Sample rate not supported
-    return features["max_freq"] < fs
+    if features["max_freq"] < fs:
+        return True
+    # XTAGs not present
+    xtag_ids = get_xtag_dut_and_harness(pytestconfig, board)
+    if not all(xtag_ids):
+        return True
+    return False
 
 
-def analogue_input_uncollect(level, board_config, fs):
-    features = get_config_features(board_config)
-    if analogue_common_uncollect(fs, features):
+def analogue_input_uncollect(pytestconfig, board, config, fs):
+    features = get_config_features(board, config)
+    if analogue_common_uncollect(fs, features, board, pytestconfig):
         return True
     if not features["analogue_i"]:
         # No input channels
@@ -36,9 +39,9 @@ def analogue_input_uncollect(level, board_config, fs):
     return False
 
 
-def analogue_output_uncollect(level, board_config, fs):
-    features = get_config_features(board_config)
-    if analogue_common_uncollect(fs, features):
+def analogue_output_uncollect(pytestconfig, board, config, fs):
+    features = get_config_features(board, config)
+    if analogue_common_uncollect(fs, features, board, pytestconfig):
         return True
     if not features["analogue_o"]:
         # No output channels
@@ -58,52 +61,30 @@ def analogue_duration(level, partial):
 
 @pytest.mark.uncollect_if(func=analogue_input_uncollect)
 @pytest.mark.parametrize("fs", samp_freqs)
-@pytest.mark.parametrize("board_config", list_configs())
-def test_analogue_input(pytestconfig, xtag_wrapper, xsig, board_config, fs):
-    features = get_config_features(board_config)
+@pytest.mark.parametrize(["board", "config"], list_configs())
+def test_analogue_input(pytestconfig, board, config, fs):
+    features = get_config_features(board, config)
+
     xsig_config = f'mc_analogue_input_{features["analogue_i"]}ch'
-    if "xk_316_mc" in board_config and features["tdm8"]:
+    if board == "xk_316_mc" and features["tdm8"]:
         xsig_config = (
             "mc_analogue_input_4ch"  # Requires jumper change to test > 4 channels
         )
     xsig_config_path = Path(__file__).parent / "xsig_configs" / f"{xsig_config}.json"
-    adapter_dut, adapter_harness = xtag_wrapper
+
+    adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
 
     duration = analogue_duration(pytestconfig.getoption("level"), features["partial"])
 
-    board_config = board_config.split("-", maxsplit=1)
-    board = board_config[0]
-    config = board_config[1]
+    with (
+        XrunDut(adapter_dut, board, config) as dut,
+        AudioAnalyzerHarness(adapter_harness) as harness,
+        XsigInput(fs, duration, xsig_config_path, dut.dev_name) as xsig_proc,
+    ):
 
-    # xrun the harness
-    harness_firmware = get_firmware_path_harness("xcore200_mc")
-    subprocess.run(
-        ["xrun", "--adapter-id", adapter_harness, harness_firmware], check=True
-    )
-    # xflash the firmware
-    firmware = get_firmware_path(board, config)
-    subprocess.run(["xrun", "--adapter-id", adapter_dut, firmware], check=True)
-
-    wait_for_portaudio(board, config)
-
-    # Run xsig
-    xsig_duration = duration + 5
-    with tempfile.NamedTemporaryFile(mode="w+") as out_file:
-        run_audio_command(
-            out_file, xsig, f"{fs}", f"{duration * 1000}", xsig_config_path
-        )
-        time.sleep(xsig_duration)
-        out_file.seek(0)
-        xsig_lines = out_file.readlines()
-
-    # Harness is still running, so break in with xgdb to stop it
-    subprocess.check_output(
-        [
-            "xgdb",
-            f"--eval-command=connect --adapter-id {adapter_harness}",
-            "--eval-command=quit",
-        ]
-    )
+        # Sleep for a few extra seconds so that xsig will have completed
+        time.sleep(duration + 5)
+        xsig_lines = xsig_proc.get_output()
 
     # Check output
     with open(xsig_config_path) as file:
@@ -113,49 +94,30 @@ def test_analogue_input(pytestconfig, xtag_wrapper, xsig, board_config, fs):
 
 @pytest.mark.uncollect_if(func=analogue_output_uncollect)
 @pytest.mark.parametrize("fs", samp_freqs)
-@pytest.mark.parametrize("board_config", list_configs())
-def test_analogue_output(pytestconfig, xtag_wrapper, xsig, board_config, fs):
-    features = get_config_features(board_config)
+@pytest.mark.parametrize(["board", "config"], list_configs())
+def test_analogue_output(pytestconfig, board, config, fs):
+    features = get_config_features(board, config)
+
     xsig_config = f'mc_analogue_output_{features["analogue_o"]}ch'
-    if "xk_316_mc" in board_config and features["tdm8"]:
+    if board == "xk_316_mc" and features["tdm8"]:
         xsig_config = "mc_analogue_output_2ch"
-    elif "xk_216_mc" in board_config and features["tdm8"] and features["i2s"] == "S":
+    elif board == "xk_216_mc" and features["tdm8"] and features["i2s"] == "S":
         xsig_config += "_paired"  # Pairs of channels can be swapped in hardware
     xsig_config_path = Path(__file__).parent / "xsig_configs" / f"{xsig_config}.json"
-    adapter_dut, adapter_harness = xtag_wrapper
+
+    adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
 
     duration = analogue_duration(pytestconfig.getoption("level"), features["partial"])
 
-    board_config = board_config.split("-", maxsplit=1)
-    board = board_config[0]
-    config = board_config[1]
+    with (
+        XrunDut(adapter_dut, board, config) as dut,
+        AudioAnalyzerHarness(adapter_harness, xscope="io") as harness,
+        XsigOutput(fs, None, xsig_config_path, dut.dev_name),
+    ):
 
-    # xrun the dut
-    firmware = get_firmware_path(board, config)
-    subprocess.run(["xrun", "--adapter-id", adapter_dut, firmware], check=True)
-
-    wait_for_portaudio(board, config)
-
-    # xrun --xscope the harness
-    harness_firmware = get_firmware_path_harness("xcore200_mc")
-    harness_proc = subprocess.Popen(
-        ["xrun", "--adapter-id", adapter_harness, "--xscope", harness_firmware],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-
-    # Run xsig for duration + 2 seconds
-    xsig_proc = subprocess.Popen(
-        [xsig, f"{fs}", f"{(duration + 2) * 1000}", xsig_config_path]
-    )
-    time.sleep(duration)
-
-    harness_proc.send_signal(signal.SIGINT)
-    xsig_proc.terminate()
-
-    xscope_str = harness_proc.stdout.read()
-    xscope_lines = xscope_str.splitlines()
+        time.sleep(duration)
+        harness.terminate()
+        xscope_lines = harness.get_output()
 
     with open(xsig_config_path) as file:
         xsig_json = json.load(file)

--- a/tests/test_spdif.py
+++ b/tests/test_spdif.py
@@ -4,36 +4,54 @@ import pytest
 import subprocess
 import time
 import json
-import tempfile
-import signal
 
 from usb_audio_test_utils import (
-    wait_for_portaudio,
-    get_firmware_path_harness,
-    get_firmware_path,
-    run_audio_command,
     check_analyzer_output,
-    get_xscope_port_number,
-    wait_for_xscope_port,
+    get_xtag_dut_and_harness,
+    AudioAnalyzerHarness,
+    XrunDut,
+    XsigInput,
+    XsigOutput,
 )
 from conftest import list_configs, get_config_features
+
+
+class SpdifClockSrc:
+    def __init__(self):
+        self.volcontrol = Path(__file__).parent / "tools" / "volcontrol" / "volcontrol"
+
+    def __enter__(self):
+        subprocess.run([self.volcontrol, "--clock", "SPDIF"], timeout=10)
+        # Short delay to wait for clock source
+        time.sleep(1)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        subprocess.run([self.volcontrol, "--clock", "Internal"], timeout=10)
 
 
 samp_freqs = [44100, 48000, 88200, 96000, 176400, 192000]
 
 
-def spdif_common_uncollect(fs, features):
-    return features["max_freq"] < fs
+def spdif_common_uncollect(fs, features, board, pytestconfig):
+    # Sample rate not supported
+    if features["max_freq"] < fs:
+        return True
+    xtag_ids = get_xtag_dut_and_harness(pytestconfig, board)
+    # XTAGs not present
+    if not all(xtag_ids):
+        return True
+    return False
 
 
-def spdif_input_uncollect(level, board_config, fs):
-    features = get_config_features(board_config)
-    return any([not features["spdif_i"], spdif_common_uncollect(fs, features)])
+def spdif_input_uncollect(pytestconfig, board, config, fs):
+    features = get_config_features(board, config)
+    return any([not features["spdif_i"], spdif_common_uncollect(fs, features, board, pytestconfig)])
 
 
-def spdif_output_uncollect(level, board_config, fs):
-    features = get_config_features(board_config)
-    return any([not features["spdif_o"], spdif_common_uncollect(fs, features)])
+def spdif_output_uncollect(pytestconfig, board, config, fs):
+    features = get_config_features(board, config)
+    return any([not features["spdif_o"], spdif_common_uncollect(fs, features, board, pytestconfig)])
 
 
 def spdif_duration(level, partial):
@@ -48,69 +66,40 @@ def spdif_duration(level, partial):
 
 @pytest.mark.uncollect_if(func=spdif_input_uncollect)
 @pytest.mark.parametrize("fs", samp_freqs)
-@pytest.mark.parametrize("board_config", list_configs())
-def test_spdif_input(pytestconfig, xtag_wrapper, xsig, board_config, fs):
-    features = get_config_features(board_config)
+@pytest.mark.parametrize(["board", "config"], list_configs())
+def test_spdif_input(pytestconfig, board, config, fs):
+    features = get_config_features(board, config)
+
     xsig_config = f'mc_digital_input_{features["analogue_i"]}ch'
     xsig_config_path = Path(__file__).parent / "xsig_configs" / f"{xsig_config}.json"
-    adapter_dut, adapter_harness = xtag_wrapper
+
+    adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
 
     duration = spdif_duration(pytestconfig.getoption("level"), features["partial"])
 
-    board_config = board_config.split("-", maxsplit=1)
-    board = board_config[0]
-    config = board_config[1]
+    with (
+        XrunDut(adapter_dut, board, config) as dut,
+        AudioAnalyzerHarness(adapter_harness, config="spdif_test", xscope="app") as harness,
+    ):
 
-    xscope_port = get_xscope_port_number()
-
-    # Run the harness and set the sample rate for the ramp signal
-    harness_firmware = get_firmware_path_harness("xcore200_mc", config="spdif_test")
-    harness_proc = subprocess.Popen(
-        [
-            "xrun",
-            "--adapter-id",
-            adapter_harness,
-            "--xscope-port",
-            f"localhost:{xscope_port}",
-            harness_firmware,
-        ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-
-    wait_for_xscope_port(xscope_port)
-
-    xscope_controller = (
-        Path(__file__).parents[2]
-        / "sw_audio_analyzer"
-        / "host_xscope_controller"
-        / "bin_macos"
-        / "xscope_controller"
-    )
-    subprocess.run([xscope_controller, "localhost", f"{xscope_port}", "0", f"f {fs}"])
-
-    firmware = get_firmware_path(board, config)
-    subprocess.run(["xrun", "--adapter-id", adapter_dut, firmware])
-
-    wait_for_portaudio(board, config)
-
-    volcontrol_path = Path(__file__).parent / "tools" / "volcontrol" / "volcontrol"
-    subprocess.run([volcontrol_path, "--clock", "SPDIF"])
-
-    # Run xsig
-    xsig_duration = duration + 5
-    with tempfile.NamedTemporaryFile(mode="w+") as out_file:
-        run_audio_command(
-            out_file, xsig, f"{fs}", f"{duration * 1000}", xsig_config_path
+        xscope_controller = (
+            Path(__file__).parents[2]
+            / "sw_audio_analyzer"
+            / "host_xscope_controller"
+            / "bin_macos"
+            / "xscope_controller"
         )
-        time.sleep(xsig_duration)
-        out_file.seek(0)
-        xsig_lines = out_file.readlines()
+        subprocess.run([xscope_controller, "localhost", f"{harness.xscope_port}", "0", f"f {fs}"], timeout=10)
+        # Short delay to wait for the S/PDIF ramp to be generated before selecting the clock source
+        time.sleep(3)
 
-    harness_proc.send_signal(signal.SIGINT)
+        with (
+            SpdifClockSrc(),
+            XsigInput(fs, duration, xsig_config_path, dut.dev_name) as xsig_proc,
+        ):
 
-    # Return to using to the internal clock
-    subprocess.run([volcontrol_path, "--clock", "Internal"])
+            time.sleep(duration + 5)
+            xsig_lines = xsig_proc.get_output()
 
     # Check output
     with open(xsig_config_path) as file:
@@ -120,47 +109,27 @@ def test_spdif_input(pytestconfig, xtag_wrapper, xsig, board_config, fs):
 
 @pytest.mark.uncollect_if(func=spdif_output_uncollect)
 @pytest.mark.parametrize("fs", samp_freqs)
-@pytest.mark.parametrize("board_config", list_configs())
-def test_spdif_output(pytestconfig, xtag_wrapper, xsig, board_config, fs):
-    features = get_config_features(board_config)
+@pytest.mark.parametrize(["board", "config"], list_configs())
+def test_spdif_output(pytestconfig, board, config, fs):
+    features = get_config_features(board, config)
+
     xsig_config = f'mc_digital_output_{features["analogue_o"]}ch'
     xsig_config_path = Path(__file__).parent / "xsig_configs" / f"{xsig_config}.json"
-    adapter_dut, adapter_harness = xtag_wrapper
+
+    adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
 
     duration = spdif_duration(pytestconfig.getoption("level"), features["partial"])
 
-    board_config = board_config.split("-", maxsplit=1)
-    board = board_config[0]
-    config = board_config[1]
+    with (
+        XrunDut(adapter_dut, board, config) as dut,
+        AudioAnalyzerHarness(adapter_harness, config="spdif_test", xscope="io") as harness,
+        XsigOutput(fs, None, xsig_config_path, dut.dev_name),
+    ):
 
-    firmware = get_firmware_path(board, config)
-    subprocess.run(["xrun", "--adapter-id", adapter_dut, firmware])
-
-    wait_for_portaudio(board, config)
-
-    # Run xsig for longer than the test duration as it will be terminated later
-    xsig_duration_ms = (duration + 100) * 1000
-    xsig_proc = subprocess.Popen(
-        [xsig, f"{fs}", f"{xsig_duration_ms}", xsig_config_path]
-    )
-
-    harness_firmware = get_firmware_path_harness("xcore200_mc", config="spdif_test")
-    harness_proc = subprocess.Popen(
-        ["xrun", "--adapter-id", adapter_harness, "--xscope", harness_firmware],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-
-    time.sleep(duration)
-
-    harness_proc.send_signal(signal.SIGINT)
-    xscope_str = harness_proc.stdout.read()
-    xscope_lines = xscope_str.splitlines()
-
-    xsig_proc.terminate()
+        time.sleep(duration)
+        harness.terminate()
+        xscope_lines = harness.get_output()
 
     with open(xsig_config_path) as file:
         xsig_json = json.load(file)
-
     check_analyzer_output(xscope_lines, xsig_json["out"])

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1,23 +1,20 @@
 # Copyright (c) 2022, XMOS Ltd, All rights reserved
-import io
 from pathlib import Path
 import pytest
 import time
 import json
 import subprocess
-import re
-import signal
 import tempfile
 
 from usb_audio_test_utils import (
-    wait_for_portaudio,
-    get_firmware_path_harness,
-    get_firmware_path,
-    run_audio_command,
     check_analyzer_output,
-    get_xscope_port_number,
-    wait_for_xscope_port,
+    get_xtag_dut_and_harness,
+    AudioAnalyzerHarness,
+    XrunDut,
+    XsigInput,
+    XsigOutput,
 )
+from conftest import get_config_features
 
 
 class Volcontrol:
@@ -29,7 +26,7 @@ class Volcontrol:
         self.input_output = input_output
 
     def reset(self):
-        subprocess.run([self.EXECUTABLE, "--resetall", self.reset_chans], check=True)
+        subprocess.run([self.EXECUTABLE, "--resetall", self.reset_chans], check=True, timeout=10)
         # sleep after resetting to allow the analyzer to detect the change
         time.sleep(3)
 
@@ -37,46 +34,41 @@ class Volcontrol:
         subprocess.run(
             [self.EXECUTABLE, "--set", self.input_output, self.channel, f"{value}"],
             check=True,
+            timeout=10,
         )
         # sleep after setting the volume to allow the analyzer to detect the change
         time.sleep(3)
 
 
-num_chans = {
-    "xk_216_mc": 8,
-    "xk_316_mc": 8,
-    "xk_evk_xu316": 2,
-}
-
-
 # Test cases are defined by a tuple of (board, config, sample rate, 'm' (master) or channel number)
 volume_configs = [
-    *[
-        ("xk_316_mc", "2AMi10o10xssxxx", 96000, ch)
-        for ch in ["m", *range(8)]
-    ],
-    *[
-        ("xk_evk_xu316", "2AMi2o2xxxxxx", 48000, ch)
-        for ch in ["m", *range(2)]
-    ],
+    *[("xk_316_mc", "2AMi10o10xssxxx", 96000, ch) for ch in ["m", *range(8)]],
+    *[("xk_evk_xu316", "2AMi2o2xxxxxx", 48000, ch) for ch in ["m", *range(2)]],
 ]
 
 
-def volume_uncollect(level, board, config, fs, channel):
-    if level == "smoke":
-        return board != "xk_evk_xu316"
+def volume_uncollect(pytestconfig, board, config, fs, channel):
+    xtag_ids = get_xtag_dut_and_harness(pytestconfig, board)
+    # XTAGs not present
+    if not all(xtag_ids):
+        return True
+    if pytestconfig.getoption("level") == "smoke":
+        # Only test master volume on one board at smoke level
+        return board != "xk_316_mc" or channel != "m"
     return False
 
 
 @pytest.mark.uncollect_if(func=volume_uncollect)
 @pytest.mark.parametrize(["board", "config", "fs", "channel"], volume_configs)
-def test_volume_input(xtag_wrapper, xsig, board, config, fs, channel):
-    channels = range(num_chans[board]) if channel == "m" else [channel]
+def test_volume_input(pytestconfig, board, config, fs, channel):
+    features = get_config_features(board, config)
+    num_chans = features["analogue_i"]
+    channels = range(num_chans) if channel == "m" else [channel]
 
     duration = 25
 
     # Load JSON xsig_config data
-    xsig_config = f"mc_analogue_input_{num_chans[board]}ch.json"
+    xsig_config = f"mc_analogue_input_{num_chans}ch.json"
     xsig_config_path = Path(__file__).parent / "xsig_configs" / xsig_config
     with open(xsig_config_path) as file:
         xsig_json = json.load(file)
@@ -85,43 +77,38 @@ def test_volume_input(xtag_wrapper, xsig, board, config, fs, channel):
         if ch in channels:
             xsig_json["in"][ch][0] = "volcheck"
 
-    adapter_dut, adapter_harness = xtag_wrapper
+    adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
 
-    # xrun the harness
-    harness_firmware = get_firmware_path_harness("xcore200_mc")
-    subprocess.run(
-        ["xrun", "--adapter-id", adapter_harness, harness_firmware], check=True
-    )
-    # xflash the firmware
-    firmware = get_firmware_path(board, config)
-    subprocess.run(["xrun", "--adapter-id", adapter_dut, firmware], check=True)
+    with (
+        XrunDut(adapter_dut, board, config) as dut,
+        AudioAnalyzerHarness(adapter_harness) as harness,
+        tempfile.NamedTemporaryFile(mode="w") as xsig_file,
+    ):
 
-    wait_for_portaudio(board, config)
-
-    with tempfile.NamedTemporaryFile(
-        mode="w+"
-    ) as out_file, tempfile.NamedTemporaryFile(mode="w") as xsig_file:
         json.dump(xsig_json, xsig_file)
         xsig_file.flush()
 
-        run_audio_command(
-            out_file, xsig, f"{fs}", f"{duration * 1000}", Path(xsig_file.name)
-        )
+        with XsigInput(fs, duration, Path(xsig_file.name), dut.dev_name) as xsig_proc:
+            start_time = time.time()
+            # Allow five extra seconds to ensure xsig has completed
+            end_time = start_time + duration + 5
 
-        time.sleep(5)
+            time.sleep(5)
 
-        if channel == "m":
-            vol_in = Volcontrol("input", num_chans[board], master=True)
-        else:
-            vol_in = Volcontrol("input", num_chans[board], channel=int(channel))
+            if channel == "m":
+                vol_in = Volcontrol("input", num_chans, master=True)
+            else:
+                vol_in = Volcontrol("input", num_chans, channel=int(channel))
 
-        vol_in.reset()
-        vol_changes = [0.5, 1.0, 0.75, 1.0]
-        for vol_change in vol_changes:
-            vol_in.set(vol_change)
+            vol_in.reset()
+            vol_changes = [0.5, 1.0, 0.75, 1.0]
+            for vol_change in vol_changes:
+                vol_in.set(vol_change)
 
-        out_file.seek(0)
-        xsig_lines = out_file.readlines()
+            current_time = time.time()
+            if current_time < end_time:
+                time.sleep(end_time - current_time)
+            xsig_lines = xsig_proc.get_output()
 
     # Check output
     check_analyzer_output(xsig_lines, xsig_json["in"])
@@ -129,77 +116,57 @@ def test_volume_input(xtag_wrapper, xsig, board, config, fs, channel):
 
 @pytest.mark.uncollect_if(func=volume_uncollect)
 @pytest.mark.parametrize(["board", "config", "fs", "channel"], volume_configs)
-def test_volume_output(xtag_wrapper, xsig, board, config, fs, channel):
-    channels = range(num_chans[board]) if channel == "m" else [channel]
+def test_volume_output(pytestconfig, board, config, fs, channel):
+    features = get_config_features(board, config)
+    num_chans = features["analogue_o"]
+    channels = range(num_chans) if channel == "m" else [channel]
 
-    xsig_config = f"mc_analogue_output_{num_chans[board]}ch.json"
+    xsig_config = f"mc_analogue_output_{num_chans}ch.json"
     xsig_config_path = Path(__file__).parent / "xsig_configs" / xsig_config
 
-    adapter_dut, adapter_harness = xtag_wrapper
+    adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
 
-    # xrun the dut
-    firmware = get_firmware_path(board, config)
-    subprocess.run(["xrun", "--adapter-id", adapter_dut, firmware], check=True)
+    with (
+        XrunDut(adapter_dut, board, config) as dut,
+        AudioAnalyzerHarness(adapter_harness, xscope="app") as harness,
+        XsigOutput(fs, None, xsig_config_path, dut.dev_name),
+    ):
 
-    wait_for_portaudio(board, config)
+        # Set the channels being tested to 'volume' mode on the analyzer
+        analyser_cmds = [f"m {ch} v" for ch in channels]
+        xscope_controller = (
+            Path(__file__).parents[2]
+            / "sw_audio_analyzer"
+            / "host_xscope_controller"
+            / "bin_macos"
+            / "xscope_controller"
+        )
+        subprocess.run(
+            [
+                xscope_controller,
+                "localhost",
+                f"{harness.xscope_port}",
+                "0",
+                *analyser_cmds,
+            ],
+            check=True,
+            timeout=10,
+        )
 
-    # Run for long duration to outlast the volume changes; xsig is terminated before it completes
-    duration = 100
-    xsig_proc = subprocess.Popen(
-        [xsig, f"{fs}", f"{duration * 1000}", xsig_config_path]
-    )
+        time.sleep(2)
 
-    xscope_port = get_xscope_port_number()
+        if channel == "m":
+            vol_out = Volcontrol("output", num_chans, master=True)
+        else:
+            vol_out = Volcontrol("output", num_chans, channel=channel)
 
-    # xrun the harness
-    harness_firmware = get_firmware_path_harness("xcore200_mc")
-    harness_proc = subprocess.Popen(
-        [
-            "xrun",
-            "--adapter-id",
-            adapter_harness,
-            "--xscope-port",
-            f"localhost:{xscope_port}",
-            harness_firmware,
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
+        vol_out.reset()
+        vol_changes = [0.5, 1.0, 0.75, 1.0]
+        for vol_change in vol_changes:
+            vol_out.set(vol_change)
 
-    wait_for_xscope_port(xscope_port)
-
-    # Set the channels being tested to 'volume' mode on the analyzer
-    analyser_cmds = [f"m {ch} v" for ch in channels]
-    xscope_controller = (
-        Path(__file__).parents[2]
-        / "sw_audio_analyzer"
-        / "host_xscope_controller"
-        / "bin_macos"
-        / "xscope_controller"
-    )
-    subprocess.run(
-        [xscope_controller, "localhost", f"{xscope_port}", "0", *analyser_cmds],
-        check=True,
-    )
-
-    time.sleep(2)
-
-    if channel == "m":
-        vol_out = Volcontrol("output", num_chans[board], master=True)
-    else:
-        vol_out = Volcontrol("output", num_chans[board], channel=channel)
-
-    vol_out.reset()
-    vol_changes = [0.5, 1.0, 0.75, 1.0]
-    for vol_change in vol_changes:
-        vol_out.set(vol_change)
-
-    harness_proc.send_signal(signal.SIGINT)
-    xsig_proc.terminate()
-
-    xscope_str = harness_proc.stdout.read()
-    xscope_lines = xscope_str.splitlines()
+        harness.terminate()
+        xscope_lines = harness.get_output()
 
     # Load JSON xsig config data
     with open(xsig_config_path) as file:


### PR DESCRIPTION
This grew into quite a big set of changes as I found and fixed lots of little issues while preparing for adding Windows tests. The main changes are:
- the MacOS privacy workaround is more robust: it now creates a Python script to run locally on the desktop Terminal, and this uses subprocess with a timeout so that xsig can't get stuck and block all subsequent tests from running
- use classes with context-managers for the audio analyzer, xrunning the USB Audio app, S/PDIF clock source and xsig; this makes cleaning up after an error more reliable (also makes the test cases a bit cleaner by reusing common code to run the apps)
- select the USB Audio device by name in portaudio and when running xsig
- added `xtc_version` function to get the version of tools being used; this was helpful when I kept switching between 15.1.4 and 15.2.1, and means we don't need to change the factory-version in test_dfu when the tools change
- removed xtag_wrapper fixture and have each test get the required XTAG IDs from the data in conftest; previously the DFU test, which only needs a single device with XTAG, required XTAG IDs for a DUT and audio analyzer harness