### PR TITLE
Adjust test timing to avoid timeouts/errors seen in nightly testing

### DIFF
--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -72,7 +72,7 @@ def analogue_duration(level, partial):
     elif level == "nightly":
         duration = 15 if partial else 180
     else:
-        duration = 5
+        duration = 10
     return duration
 
 
@@ -100,7 +100,7 @@ def test_analogue_input(pytestconfig, board, config, fs):
     ):
 
         # Sleep for a few extra seconds so that xsig will have completed
-        time.sleep(duration + 5)
+        time.sleep(duration + 6)
         xsig_lines = xsig_proc.get_output()
 
     # Check output

--- a/tests/test_spdif.py
+++ b/tests/test_spdif.py
@@ -24,7 +24,7 @@ class SpdifClockSrc:
     def __enter__(self):
         subprocess.run([self.volcontrol, "--clock", "SPDIF"], timeout=10)
         # Short delay to wait for clock source
-        time.sleep(3)
+        time.sleep(5)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -64,7 +64,7 @@ def spdif_duration(level, partial):
     elif level == "nightly":
         duration = 15 if partial else 180
     else:
-        duration = 5
+        duration = 10
     return duration
 
 
@@ -102,7 +102,7 @@ def test_spdif_input(pytestconfig, board, config, fs):
             XsigInput(fs, duration, xsig_config_path, dut.dev_name) as xsig_proc,
         ):
 
-            time.sleep(duration + 5)
+            time.sleep(duration + 6)
             xsig_lines = xsig_proc.get_output()
 
     # Check output

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -94,8 +94,8 @@ def test_volume_input(pytestconfig, board, config, fs, channel):
 
         with XsigInput(fs, duration, Path(xsig_file.name), dut.dev_name) as xsig_proc:
             start_time = time.time()
-            # Allow five extra seconds to ensure xsig has completed
-            end_time = start_time + duration + 5
+            # Allow some extra time to ensure xsig has completed
+            end_time = start_time + duration + 7
 
             time.sleep(5)
 

--- a/tests/usb_audio_test_utils.py
+++ b/tests/usb_audio_test_utils.py
@@ -51,7 +51,8 @@ def product_str_from_board_config(board, config):
     pytest.fail(f"Unrecognised config {config} for {board}")
 
 
-def wait_for_portaudio(board, config, timeout=10):
+def wait_for_portaudio(board, config):
+    timeout = 30
     prod_str = product_str_from_board_config(board, config)
 
     for _ in range(timeout):
@@ -444,7 +445,7 @@ class XsigInput(XsigProcess):
                     'from pathlib import PosixPath\n'
                     f'with open("{self.output_file.name}", "w+") as f:\n'
                     '    try:\n'
-                    f'        ret = subprocess.run({self.xsig_cmd}, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout={self.duration+3})\n'
+                    f'        ret = subprocess.run({self.xsig_cmd}, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout={self.duration+5})\n'
                     f'    except subprocess.TimeoutExpired:\n'
                     f'        f.write("Timeout running command: {self.xsig_cmd}")\n'
                     '    else:\n'


### PR DESCRIPTION
The 5s short tests weren't long enough in some cases, particularly on Windows where the agent seems to respond a little slowly in general while running lots of audio tests.

The privacy workaround on the MacOS agents was seeing some timeouts where `duration+3` was insufficient to run xsig; `duration+5` should be good. Increasing things like this makes the smoke run longer, so I'm trying not to add too much.

Sometimes I've seen S/PDIF input tests fail because the device hasn't synced to the clock source, so I've increased the delay for that as well.