### PR TITLE
Refactor testcases

### DIFF
--- a/app_usb_aud_xk_evk_xu316/Makefile
+++ b/app_usb_aud_xk_evk_xu316/Makefile
@@ -35,21 +35,10 @@ USED_MODULES = lib_xua lib_i2c
 XCC_FLAGS_1AMi2o2xxxxxx = $(BUILD_FLAGS) -DAUDIO_CLASS=1
 INCLUDE_ONLY_IN_1AMi2o2xxxxxx =
 
+# Audio Class 2, Async, I2S Master, 2xInput, 2xOutput
+XCC_FLAGS_2AMi2o2xxxxxx = $(BUILD_FLAGS)
+INCLUDE_ONLY_IN_2AMi2o2xxxxxx =
 
-ifneq ($(CONFIG),)
-BUILD_TEST_CONFIGS = 1
-endif
-
-BUILD_TEST_CONFIGS ?= 0
-ifeq ($(BUILD_TEST_CONFIGS),1)
-include configs_build.inc
-PARTIAL_TEST_CONFIGS = 1
-endif
-
-PARTIAL_TEST_CONFIGS ?= 0
-ifeq ($(PARTIAL_TEST_CONFIGS),1)
-include configs_partial.inc
-endif
 
 TEST_SUPPORT_CONFIGS ?= 0
 ifeq ($(TEST_SUPPORT_CONFIGS),1)

--- a/app_usb_aud_xk_evk_xu316/configs_build.inc
+++ b/app_usb_aud_xk_evk_xu316/configs_build.inc
@@ -1,2 +1,0 @@
-# Configs that have only had their build process tested
-

--- a/app_usb_aud_xk_evk_xu316/configs_partial.inc
+++ b/app_usb_aud_xk_evk_xu316/configs_partial.inc
@@ -1,6 +1,0 @@
-# Configs that have been partially tested, but not as comprehensively as those in the Makefile
-
-# Audio Class 2, Async, I2S Master, 2xInput, 2xOutput
-XCC_FLAGS_2AMi2o2xxxxxx = $(BUILD_FLAGS)
-INCLUDE_ONLY_IN_2AMi2o2xxxxxx =
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,12 @@ boards = ["xk_216_mc", "xk_316_mc", "xk_evk_xu316"]
 board_configs = {}
 
 
+all_freqs = [44100, 48000, 88200, 96000, 176400, 192000]
+
+def samp_freqs_upto(max):
+    return [fs for fs in all_freqs if fs <= max]
+
+
 def parse_features(board, config):
     max_analogue_chans = 8
 
@@ -73,22 +79,22 @@ def parse_features(board, config):
         features["analogue_i"] = 0
         features["analogue_o"] = 0
 
-    # Set the maximum sample rate frequency
+    # Create list of supported sample frequencies
     if config == "1AMi8o2xxxxxx":
-        features["max_freq"] = 44100
+        features["samp_freqs"] = samp_freqs_upto(44100)
     elif features["uac"] == 1:
         if features["chan_i"] and features["chan_o"]:
-            features["max_freq"] = 48000
+            features["samp_freqs"] = samp_freqs_upto(48000)
         else:
-            features["max_freq"] = 96000
+            features["samp_freqs"] = samp_freqs_upto(96000)
     elif features["chan_i"] >= 32 or features["chan_o"] >= 32:
-        features["max_freq"] = 48000
+        features["samp_freqs"] = samp_freqs_upto(48000)
     elif features["chan_i"] >= 16 or features["chan_o"] >= 16:
-        features["max_freq"] = 96000
+        features["samp_freqs"] = samp_freqs_upto(96000)
     elif features["tdm8"]:
-        features["max_freq"] = 96000
+        features["samp_freqs"] = samp_freqs_upto(96000)
     else:
-        features["max_freq"] = 192000
+        features["samp_freqs"] = samp_freqs_upto(192000)
 
     return features
 

--- a/tests/usb_audio_test_utils.py
+++ b/tests/usb_audio_test_utils.py
@@ -187,8 +187,7 @@ def check_analyzer_output(analyzer_output, xsig_config):
         else:
             failures.append(f"Invalid channel config {channel_config}")
 
-    if len(failures) > 0:
-        pytest.fail("Checking analyser output failed:\n" + "\n".join(failures))
+    return failures
 
 
 # Get an available port number by binding a socket then closing it (assuming nothing else takes it before it's used by xrun)


### PR DESCRIPTION
The supported sample frequencies are a feature of the board config, not of the test, so I've refactored the tests to populate a list of supported frequencies from the board config string, and then loop the analogue and S/PDIF tests over this list of frequencies. As a result, test reporting should be easier because now there is a single input analogue test per config, which checks all supported sample rates (and likewise for output tests and S/PDIF).