### PR TITLE
Remove use of requests Python module in favour of standard urllib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # python_version 3.10.5
 
 pytest==7.1.2
-requests==2.27.1
 sounddevice==0.4.4

--- a/tests/test_dfu.py
+++ b/tests/test_dfu.py
@@ -9,7 +9,7 @@ import configparser
 import os
 import re
 import stat
-import requests
+import urllib.request
 
 from usb_audio_test_utils import get_firmware_path, get_xtag_dut, xtc_version, stop_xrun_app
 from conftest import get_config_features
@@ -58,9 +58,9 @@ class DfuTester:
             if not xmosdfu_path.exists():
                 os_dir = "macos" if platform_str == "Darwin" else "linux"
                 xmosdfu_url = f"http://intranet.xmos.local/projects/usb_audio_regression_files/xmosdfu/{os_dir}/xmosdfu"
-                r = requests.get(xmosdfu_url)
+                r = urllib.request.urlopen(xmosdfu_url)
                 with open(xmosdfu_path, "wb") as f:
-                    f.write(r.content)
+                    f.write(r.read())
                 xmosdfu_path.chmod(stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)
             self.dfu_app = xmosdfu_path
 


### PR DESCRIPTION
Just a small cleanup where we don't need the requests module for the simple get that we do; the standard urllib module can be used instead.