### PR TITLE
Use application defaults in xua_conf.h ahead of lib_xua defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ UNRELEASED
   * ADDED:     Driver information section to documentation
   * CHANGED:   AppPLL settings to reduce jitter (#112)
   * FIXED:     Configuration of DACs when changing sample rate (#110)
+  * FIXED:     Define app defaults ahead of lib_xua defaults (xk_216_mc)
 
 7.1.0
 -----

--- a/app_usb_aud_xk_216_mc/src/core/app_usb_aud_xk_216_mc.h
+++ b/app_usb_aud_xk_216_mc/src/core/app_usb_aud_xk_216_mc.h
@@ -4,8 +4,6 @@
 #ifndef APP_USB_AUD_XK_216_MC_H_
 #define APP_USB_AUD_XK_216_MC_H_
 
-#include "xua_conf.h"
-
 /* Default to board version version 2.0 */
 #ifndef XCORE_200_MC_AUDIO_HW_VERSION
 #define XCORE_200_MC_AUDIO_HW_VERSION 2
@@ -14,8 +12,5 @@
 #ifndef USB_SEL_A
 #define USB_SEL_A    (0)
 #endif
-
-// Include this header after setting application defaults to then apply any other XUA defaults
-#include "xua_conf_full.h"
 
 #endif

--- a/app_usb_aud_xk_216_mc/src/core/xua_conf.h
+++ b/app_usb_aud_xk_216_mc/src/core/xua_conf.h
@@ -7,7 +7,6 @@
 #ifndef _XUA_CONF_H_
 #define _XUA_CONF_H_
 
-#include "app_usb_aud_xk_216_mc.h"
 #include "../../../shared/version.h"
 
 /*


### PR DESCRIPTION
`xua_conf.h` and `app_usb_aud_xk_216_mc.h` were including each other, and the result of this was that the lib_xua defaults were being defined ahead of the application-specific definitions in this repo.