### PR TITLE
Add xk_316_mc config with S/PDIF output and 8 mixes

### DIFF
--- a/app_usb_aud_xk_316_mc/configs_partial.inc
+++ b/app_usb_aud_xk_316_mc/configs_partial.inc
@@ -46,3 +46,8 @@ XCC_FLAGS_2AMi16o8xxxaxx = $(BUILD_FLAGS) 		-DXUA_ADAT_RX_EN=1
 INCLUDE_ONLY_IN_2AMi8o16xxxxax =
 XCC_FLAGS_2AMi8o16xxxxax = $(BUILD_FLAGS) 		-DXUA_ADAT_TX_EN=1
 
+# Audio Class 2, Async, I2S Master, 8xInput, 10xOutput, S/PDIF Tx (8 mixes)
+INCLUDE_ONLY_IN_2AMi8o10xxsxxx_mix8 =
+XCC_FLAGS_2AMi8o10xxsxxx_mix8 = $(BUILD_FLAGS)  -DXUA_SPDIF_TX_EN=1 \
+                                                                                                -DMAX_MIX_COUNT=8
+


### PR DESCRIPTION
Copied the config from xk_216_mc where #103 is seen so that we can get some nightly test coverage to see if it happens often on the 316 board.