### PR TITLE
Add printing of failure data on some errors

### DIFF
--- a/tests/test_mixer_ctrl.py
+++ b/tests/test_mixer_ctrl.py
@@ -50,10 +50,11 @@ def test_routing_ctrl_input(pytestconfig, ctrl_app, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / "routed_input_8ch.json"
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
     duration = 10
+    fail_str = ""
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
-        AudioAnalyzerHarness(adapter_harness),
+        AudioAnalyzerHarness(adapter_harness) as harness,
     ):
 
         # Route analogue inputs 0, 1, ..., N to host inputs N, N-1, ..., 0 respectively
@@ -71,7 +72,14 @@ def test_routing_ctrl_input(pytestconfig, ctrl_app, board, config):
         xsig_json = json.load(file)
     failures = check_analyzer_output(xsig_lines, xsig_json["in"])
     if len(failures) > 0:
-        pytest.fail(f"{failures}")
+        fail_str += "\n".join(failures) + "\n\n"
+        fail_str += "xsig stdout\n"
+        fail_str += "\n".join(xsig_lines)
+        harness_output = harness.get_output()
+        if len(harness_output) > 0:
+            fail_str += "\n\nAudio analyzer stdout\n"
+            fail_str += "\n".join(harness_output)
+        pytest.fail(fail_str)
 
 
 @pytest.mark.uncollect_if(func=mixer_uncollect)
@@ -82,6 +90,7 @@ def test_routing_ctrl_output(pytestconfig, ctrl_app, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / "mc_analogue_output_8ch.json"
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
     duration = 10
+    fail_str = ""
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
@@ -105,7 +114,10 @@ def test_routing_ctrl_output(pytestconfig, ctrl_app, board, config):
         xsig_json = json.load(file)
     failures = check_analyzer_output(xscope_lines, xsig_json["out"])
     if len(failures) > 0:
-        pytest.fail(f"{failures}")
+        fail_str += "\n".join(failures) + "\n\n"
+        fail_str += "xscope stdout\n"
+        fail_str += "\n".join(xscope_lines)
+        pytest.fail(fail_str)
 
 
 def clear_default_mixes(ctrl_app, num_mixes):
@@ -123,10 +135,11 @@ def test_mixing_ctrl_input(pytestconfig, ctrl_app, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / "routed_input_8ch.json"
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
     duration = 10
+    fail_str = ""
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
-        AudioAnalyzerHarness(adapter_harness),
+        AudioAnalyzerHarness(adapter_harness) as harness,
     ):
 
         num_mixes = 8
@@ -156,7 +169,14 @@ def test_mixing_ctrl_input(pytestconfig, ctrl_app, board, config):
         xsig_json = json.load(file)
     failures = check_analyzer_output(xsig_lines, xsig_json["in"])
     if len(failures) > 0:
-        pytest.fail(f"{failures}")
+        fail_str += "\n".join(failures) + "\n\n"
+        fail_str += "xsig stdout\n"
+        fail_str += "\n".join(xsig_lines)
+        harness_output = harness.get_output()
+        if len(harness_output) > 0:
+            fail_str += "\n\nAudio analyzer stdout\n"
+            fail_str += "\n".join(harness_output)
+        pytest.fail(fail_str)
 
 
 @pytest.mark.uncollect_if(func=mixer_uncollect)
@@ -168,6 +188,7 @@ def test_mixing_ctrl_output(pytestconfig, ctrl_app, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / "mc_analogue_output_8ch.json"
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
     duration = 10
+    fail_str = ""
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
@@ -203,7 +224,10 @@ def test_mixing_ctrl_output(pytestconfig, ctrl_app, board, config):
         xsig_json = json.load(file)
     failures = check_analyzer_output(xscope_lines, xsig_json["out"])
     if len(failures) > 0:
-        pytest.fail(f"{failures}")
+        fail_str += "\n".join(failures) + "\n\n"
+        fail_str += "xscope stdout\n"
+        fail_str += "\n".join(xscope_lines)
+        pytest.fail(fail_str)
 
 @pytest.mark.uncollect_if(func=mixer_uncollect)
 @pytest.mark.parametrize(["board", "config"], mixer_configs)
@@ -214,6 +238,7 @@ def test_mixing_multi_channel_output(pytestconfig, ctrl_app, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / "mc_analogue_output_8ch_paired_inverse_sine.json"
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
     duration = 10
+    fail_str = ""
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
@@ -252,4 +277,7 @@ def test_mixing_multi_channel_output(pytestconfig, ctrl_app, board, config):
         xsig_json = json.load(file)
     failures = check_analyzer_output(xscope_lines, xsig_json["out"])
     if len(failures) > 0:
-        pytest.fail(f"{failures}")
+        fail_str += "\n".join(failures) + "\n\n"
+        fail_str += "xscope stdout\n"
+        fail_str += "\n".join(xscope_lines)
+        pytest.fail(fail_str)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -71,12 +71,10 @@ def test_volume_input(pytestconfig, board, config):
     test_chans = ["m", *range(num_chans)]
 
     duration = 25
-
+    fail_str = ""
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
 
     with XrunDut(adapter_dut, board, config) as dut:
-        ch_failures = []
-
         for channel in test_chans:
             channels = range(num_chans) if channel == "m" else [channel]
 
@@ -122,10 +120,17 @@ def test_volume_input(pytestconfig, board, config):
 
             failures = check_analyzer_output(xsig_lines, xsig_json["in"])
             if len(failures) > 0:
-                ch_failures.append((channel, failures))
+                fail_str += f"Failure for channel {channel}\n"
+                fail_str += "\n".join(failures) + "\n\n"
+                fail_str += f"xsig stdout for channel {channel}\n"
+                fail_str += "\n".join(xsig_lines) + "\n\n"
+                harness_output = harness.get_output()
+                if len(harness_output) > 0:
+                    fail_str += f"Audio analyzer stdout for channel {channel}\n"
+                    fail_str += "\n".join(harness_output) + "\n\n"
 
-    if len(ch_failures) > 0:
-        pytest.fail(f"{ch_failures}")
+    if len(fail_str) > 0:
+        pytest.fail(fail_str)
 
 
 @pytest.mark.uncollect_if(func=volume_uncollect)
@@ -140,10 +145,9 @@ def test_volume_output(pytestconfig, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / xsig_config
 
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
+    fail_str = ""
 
     with XrunDut(adapter_dut, board, config) as dut:
-        ch_failures = []
-
         for channel in test_chans:
             channels = range(num_chans) if channel == "m" else [channel]
 
@@ -198,7 +202,10 @@ def test_volume_output(pytestconfig, board, config):
 
             failures = check_analyzer_output(xscope_lines, xsig_json["out"])
             if len(failures) > 0:
-                ch_failures.append((ch, failures))
+                fail_str += f"Failure for channel {channel}\n"
+                fail_str += "\n".join(failures) + "\n\n"
+                fail_str += f"xscope stdout for channel {channel}\n"
+                fail_str += "\n".join(xscope_lines) + "\n\n"
 
-    if len(ch_failures) > 0:
-        pytest.fail(f"{ch_failures}")
+    if len(fail_str) > 0:
+        pytest.fail(fail_str)


### PR DESCRIPTION
For tests which use xsig or the xscope output from the audio analyser app, print the full output of these on a failure so that more detail is available about what signals they saw.

When a device fails to become available via portaudio, print out a dump-state so that there is more information about possible exceptions or stuck cores.

All of these prints are captured by pytest and just displayed for failing tests.