### PR TITLE
Set pip version as Jenkins shared library version default is too old

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.20.0') _
+@Library('xmos_jenkins_shared_library@v0.23.0') _
 
 getApproval()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # python_version 3.10.5
+# pip_version 23.0.1
 
 pytest==7.1.2
 sounddevice==0.4.4


### PR DESCRIPTION
We have started to see failures on the M1 MacOS agent after some Python dependencies in infr_scripts_py (that weren't pinned) changed over the weekend. The pip version used by default in xmos_jenkins_shared_library is too old, so updating to the latest.