### PR TITLE
Add printing of failure data on some errors

### DIFF
--- a/tests/test_mixer_ctrl.py
+++ b/tests/test_mixer_ctrl.py
@@ -50,10 +50,11 @@ def test_routing_ctrl_input(pytestconfig, ctrl_app, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / "routed_input_8ch.json"
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
     duration = 10
+    fail_str = ""
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
-        AudioAnalyzerHarness(adapter_harness),
+        AudioAnalyzerHarness(adapter_harness) as harness,
     ):
 
         # Route analogue inputs 0, 1, ..., N to host inputs N, N-1, ..., 0 respectively
@@ -71,7 +72,14 @@ def test_routing_ctrl_input(pytestconfig, ctrl_app, board, config):
         xsig_json = json.load(file)
     failures = check_analyzer_output(xsig_lines, xsig_json["in"])
     if len(failures) > 0:
-        pytest.fail(f"{failures}")
+        fail_str += "\n".join(failures) + "\n\n"
+        fail_str += "xsig stdout\n"
+        fail_str += "\n".join(xsig_lines)
+        harness_output = harness.get_output()
+        if len(harness_output) > 0:
+            fail_str += "\n\nAudio analyzer stdout\n"
+            fail_str += "\n".join(harness_output)
+        pytest.fail(fail_str)
 
 
 @pytest.mark.uncollect_if(func=mixer_uncollect)
@@ -82,6 +90,7 @@ def test_routing_ctrl_output(pytestconfig, ctrl_app, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / "mc_analogue_output_8ch.json"
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
     duration = 10
+    fail_str = ""
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
@@ -105,7 +114,10 @@ def test_routing_ctrl_output(pytestconfig, ctrl_app, board, config):
         xsig_json = json.load(file)
     failures = check_analyzer_output(xscope_lines, xsig_json["out"])
     if len(failures) > 0:
-        pytest.fail(f"{failures}")
+        fail_str += "\n".join(failures) + "\n\n"
+        fail_str += "xscope stdout\n"
+        fail_str += "\n".join(xscope_lines)
+        pytest.fail(fail_str)
 
 
 def clear_default_mixes(ctrl_app, num_mixes):
@@ -123,10 +135,11 @@ def test_mixing_ctrl_input(pytestconfig, ctrl_app, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / "routed_input_8ch.json"
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
     duration = 10
+    fail_str = ""
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
-        AudioAnalyzerHarness(adapter_harness),
+        AudioAnalyzerHarness(adapter_harness) as harness,
     ):
 
         num_mixes = 8
@@ -156,7 +169,14 @@ def test_mixing_ctrl_input(pytestconfig, ctrl_app, board, config):
         xsig_json = json.load(file)
     failures = check_analyzer_output(xsig_lines, xsig_json["in"])
     if len(failures) > 0:
-        pytest.fail(f"{failures}")
+        fail_str += "\n".join(failures) + "\n\n"
+        fail_str += "xsig stdout\n"
+        fail_str += "\n".join(xsig_lines)
+        harness_output = harness.get_output()
+        if len(harness_output) > 0:
+            fail_str += "\n\nAudio analyzer stdout\n"
+            fail_str += "\n".join(harness_output)
+        pytest.fail(fail_str)
 
 
 @pytest.mark.uncollect_if(func=mixer_uncollect)
@@ -168,6 +188,7 @@ def test_mixing_ctrl_output(pytestconfig, ctrl_app, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / "mc_analogue_output_8ch.json"
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
     duration = 10
+    fail_str = ""
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
@@ -203,7 +224,10 @@ def test_mixing_ctrl_output(pytestconfig, ctrl_app, board, config):
         xsig_json = json.load(file)
     failures = check_analyzer_output(xscope_lines, xsig_json["out"])
     if len(failures) > 0:
-        pytest.fail(f"{failures}")
+        fail_str += "\n".join(failures) + "\n\n"
+        fail_str += "xscope stdout\n"
+        fail_str += "\n".join(xscope_lines)
+        pytest.fail(fail_str)
 
 @pytest.mark.uncollect_if(func=mixer_uncollect)
 @pytest.mark.parametrize(["board", "config"], mixer_configs)
@@ -214,6 +238,7 @@ def test_mixing_multi_channel_output(pytestconfig, ctrl_app, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / "mc_analogue_output_8ch_paired_inverse_sine.json"
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
     duration = 10
+    fail_str = ""
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
@@ -252,7 +277,10 @@ def test_mixing_multi_channel_output(pytestconfig, ctrl_app, board, config):
         xsig_json = json.load(file)
     failures = check_analyzer_output(xscope_lines, xsig_json["out"])
     if len(failures) > 0:
-        pytest.fail(f"{failures}")
+        fail_str += "\n".join(failures) + "\n\n"
+        fail_str += "xscope stdout\n"
+        fail_str += "\n".join(xscope_lines)
+        pytest.fail(fail_str)
 
 @pytest.mark.uncollect_if(func=mixer_uncollect)
 @pytest.mark.parametrize(["board", "config"], mixer_configs)
@@ -263,6 +291,7 @@ def test_routing_daw_out_mix_input(pytestconfig, ctrl_app, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / "mc_analogue_output_8ch.json"
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
     duration = 10
+    fail_str = ""
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
@@ -295,4 +324,7 @@ def test_routing_daw_out_mix_input(pytestconfig, ctrl_app, board, config):
         xsig_json = json.load(file)
     failures = check_analyzer_output(xscope_lines, xsig_json["out"])
     if len(failures) > 0:
-        pytest.fail(f"{failures}")
+        fail_str += "\n".join(failures) + "\n\n"
+        fail_str += "xscope stdout\n"
+        fail_str += "\n".join(xscope_lines)
+        pytest.fail(fail_str)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -71,12 +71,10 @@ def test_volume_input(pytestconfig, board, config):
     test_chans = ["m", *range(num_chans)]
 
     duration = 25
-
+    fail_str = ""
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
 
     with XrunDut(adapter_dut, board, config) as dut:
-        ch_failures = []
-
         for channel in test_chans:
             channels = range(num_chans) if channel == "m" else [channel]
 
@@ -122,10 +120,17 @@ def test_volume_input(pytestconfig, board, config):
 
             failures = check_analyzer_output(xsig_lines, xsig_json["in"])
             if len(failures) > 0:
-                ch_failures.append((channel, failures))
+                fail_str += f"Failure for channel {channel}\n"
+                fail_str += "\n".join(failures) + "\n\n"
+                fail_str += f"xsig stdout for channel {channel}\n"
+                fail_str += "\n".join(xsig_lines) + "\n\n"
+                harness_output = harness.get_output()
+                if len(harness_output) > 0:
+                    fail_str += f"Audio analyzer stdout for channel {channel}\n"
+                    fail_str += "\n".join(harness_output) + "\n\n"
 
-    if len(ch_failures) > 0:
-        pytest.fail(f"{ch_failures}")
+    if len(fail_str) > 0:
+        pytest.fail(fail_str)
 
 
 @pytest.mark.uncollect_if(func=volume_uncollect)
@@ -140,10 +145,9 @@ def test_volume_output(pytestconfig, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / xsig_config
 
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
+    fail_str = ""
 
     with XrunDut(adapter_dut, board, config) as dut:
-        ch_failures = []
-
         for channel in test_chans:
             channels = range(num_chans) if channel == "m" else [channel]
 
@@ -198,7 +202,10 @@ def test_volume_output(pytestconfig, board, config):
 
             failures = check_analyzer_output(xscope_lines, xsig_json["out"])
             if len(failures) > 0:
-                ch_failures.append((ch, failures))
+                fail_str += f"Failure for channel {channel}\n"
+                fail_str += "\n".join(failures) + "\n\n"
+                fail_str += f"xscope stdout for channel {channel}\n"
+                fail_str += "\n".join(xscope_lines) + "\n\n"
 
-    if len(ch_failures) > 0:
-        pytest.fail(f"{ch_failures}")
+    if len(fail_str) > 0:
+        pytest.fail(fail_str)

--- a/tests/usb_audio_test_utils.py
+++ b/tests/usb_audio_test_utils.py
@@ -51,7 +51,7 @@ def product_str_from_board_config(board, config):
     pytest.fail(f"Unrecognised config {config} for {board}")
 
 
-def wait_for_portaudio(board, config):
+def wait_for_portaudio(board, config, adapter_id):
     timeout = 30
     prod_str = product_str_from_board_config(board, config)
 
@@ -65,7 +65,15 @@ def wait_for_portaudio(board, config):
             if prod_str in sd_dev["name"]:
                 return sd_dev["name"]
 
-    pytest.fail(f"Device ({prod_str}) not available via portaudio in {timeout}s")
+    fail_str = f"Device ({prod_str}) not available via portaudio in {timeout}s\n"
+
+    # Device doesn't appear to have started, so dump the state of the xcore
+    firmware = get_firmware_path(board, config)
+    ret = subprocess.run(["xrun", "--adapter-id", adapter_id, "--dump-state", firmware],
+                         text=True, timeout=10, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    fail_str += "Register and thread state of the xcore device\n"
+    fail_str += "\n".join(ret.stdout.splitlines())
+    pytest.fail(fail_str)
 
 
 def get_firmware_path(board, config):
@@ -360,7 +368,7 @@ class XrunDut:
     def __enter__(self):
         firmware = get_firmware_path(self.board, self.config)
         subprocess.run(["xrun", "--adapter-id", self.adapter_id, firmware])
-        self.dev_name = wait_for_portaudio(self.board, self.config)
+        self.dev_name = wait_for_portaudio(self.board, self.config, self.adapter_id)
         if platform.system() == "Windows" and use_windows_builtin_driver(self.board, self.config):
             # Select ASIO4ALL as device for built-in driver testing (cannot wait for this device
             # name in wait_for_portaudio because it is always present)
@@ -466,7 +474,7 @@ class XsigInput(XsigProcess):
     def get_output(self):
         if platform.system() == "Darwin" and os.environ.get("USBA_MAC_PRIV_WORKAROUND", None) == "1":
             self.output_file.seek(0)
-            return self.output_file.readlines()
+            return [line.strip() for line in self.output_file.readlines()]
         return super().get_output()
 
 


### PR DESCRIPTION
Record more detailed output from xsig and audio analyzer when failures occur, and pass these onto to pytest so that they are printed in a useful way on the test result tab of a Jenkins job.