### PR TITLE
Device enumeration lookup with host OS tools instead of Python sounddevice

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@
 # pip_version 23.0.1
 
 pytest==7.1.2
-sounddevice==0.4.4


### PR DESCRIPTION
Python sounddevice is only used to check if the USB Audio device has enumerated after xrunning the XE to be tested. It isn't a very good module: it has to be terminated and re-initialised to detect hardware changes, and sometimes on the Windows agents it can take 30s to import (rather than about 1s usually). There are other Python modules for interacting with PortAudio but they have similar deficiencies. The main reason for using any of these Python modules was that it seemed sensible to use a Python module to check for device enumeration during pytest.

I think that using host OS utilities and parsing the output may be better, so this pull request is to test out this approach.

Also ran the black formatter over the file, so lots of changes are just style.