### PR TITLE
Store glitch data from xsig input tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
   stages {
     stage('Build') {
       agent {
-        label '(linux || macOS) && x86_64'
+        label 'linux && x86_64'
       }
       stages {
         stage('Get view') {
@@ -137,6 +137,7 @@ pipeline {
           post {
             always {
               archiveArtifacts artifacts: "${REPO}/tests/pytest_result_mac_intel.xml", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO}/tests/tools/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
               junit "${REPO}/tests/pytest_result_mac_intel.xml"
             }
             cleanup {
@@ -199,6 +200,7 @@ pipeline {
           post {
             always {
               archiveArtifacts artifacts: "${REPO}/tests/pytest_result_mac_arm.xml", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO}/tests/tools/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
               junit "${REPO}/tests/pytest_result_mac_arm.xml"
             }
             cleanup {
@@ -258,6 +260,7 @@ pipeline {
           post {
             always {
               archiveArtifacts artifacts: "${REPO}/tests/pytest_result_windows10.xml", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO}/tests/tools/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
               junit "${REPO}/tests/pytest_result_windows10.xml"
             }
             cleanup {
@@ -317,6 +320,7 @@ pipeline {
           post {
             always {
               archiveArtifacts artifacts: "${REPO}/tests/pytest_result_windows11.xml", fingerprint: true, allowEmptyArchive: true
+              archiveArtifacts artifacts: "${REPO}/tests/tools/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
               junit "${REPO}/tests/pytest_result_windows11.xml"
             }
             cleanup {

--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -118,7 +118,7 @@ def test_analogue_input(pytestconfig, board, config):
         AudioAnalyzerHarness(adapter_harness) as harness,
     ):
         for fs in features["samp_freqs"]:
-            with XsigInput(fs, duration, xsig_config_path, dut.dev_name) as xsig_proc:
+            with XsigInput(fs, duration, xsig_config_path, dut.dev_name, ident=f"analogue_input-{board}-{config}-{fs}") as xsig_proc:
                 # Sleep for a few extra seconds so that xsig will have completed
                 time.sleep(duration + 6)
                 xsig_lines = xsig_proc.get_output()

--- a/tests/test_mixer_ctrl.py
+++ b/tests/test_mixer_ctrl.py
@@ -64,7 +64,7 @@ def test_routing_ctrl_input(pytestconfig, ctrl_app, board, config):
             mixer_cmd = [ctrl_app, "--set-daw-channel-map", f"{ch}", f"{host_input}"]
             subprocess.run(mixer_cmd, timeout=10)
 
-        with XsigInput(fs, duration, xsig_config_path, dut.dev_name) as xsig_proc:
+        with XsigInput(fs, duration, xsig_config_path, dut.dev_name, ident=f"routing_ctrl_input-{board}-{config}") as xsig_proc:
             time.sleep(duration + 6)
             xsig_lines = xsig_proc.get_output()
 
@@ -161,7 +161,7 @@ def test_mixing_ctrl_input(pytestconfig, ctrl_app, board, config):
             mixer_cmd = [ctrl_app, "--set-value", "0", f"{(mixer_row * num_mixes) + ch}", "0"]
             subprocess.run(mixer_cmd, timeout=10)
 
-        with XsigInput(fs, duration, xsig_config_path, dut.dev_name) as xsig_proc:
+        with XsigInput(fs, duration, xsig_config_path, dut.dev_name, ident=f"mixing_ctrl_input-{board}-{config}") as xsig_proc:
             time.sleep(duration + 6)
             xsig_lines = xsig_proc.get_output()
 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -96,7 +96,7 @@ def test_volume_input(pytestconfig, board, config):
                 json.dump(xsig_json, xsig_file)
                 xsig_file.flush()
 
-                with XsigInput(fs, duration, Path(xsig_file.name), dut.dev_name) as xsig_proc:
+                with XsigInput(fs, duration, Path(xsig_file.name), dut.dev_name, ident=f"volume_input-{board}-{config}-{channel}") as xsig_proc:
                     start_time = time.time()
                     # Allow some extra time to ensure xsig has completed
                     end_time = start_time + duration + 7


### PR DESCRIPTION
xsig produces CSV files containing the signal and FFT data for the window around a glitch in the sine wave.

Add optional `ident` when running xsig as an identifying string to insert into repeated filenames to match up glitch data with individual test runs. This identifier has been added to all xsig tests that have an input analogue signal. If a glitch occurs, xsig will store the signal and FFT data from the windows around the glitch, and these are then archived on Jenkins.

Also change the Jenkins build stage to use the Linux builders only - these are preferred unless MacOS is absolutely required, which it isn't for this job.