### PR TITLE
Fix indentation to catch all I2S loopback test failures

### DIFF
--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -212,11 +212,11 @@ def test_analogue_loopback(pytestconfig, board, config):
             with open(xsig_config_path) as file:
                 xsig_json = json.load(file)
             failures = check_analyzer_output(xsig_lines, xsig_json["in"])
-        if len(failures) > 0:
-            fail_str += f"Failure at sample rate {fs}\n"
-            fail_str += "\n".join(failures) + "\n\n"
-            fail_str += f"xsig stdout at sample rate {fs}\n"
-            fail_str += "\n".join(xsig_lines) + "\n\n"
+            if len(failures) > 0:
+                fail_str += f"Failure at sample rate {fs}\n"
+                fail_str += "\n".join(failures) + "\n\n"
+                fail_str += f"xsig stdout at sample rate {fs}\n"
+                fail_str += "\n".join(xsig_lines) + "\n\n"
 
     if len(fail_str) > 0:
         pytest.fail(fail_str)


### PR DESCRIPTION
Incorrectly indented code resulted in only reporting an error when a failure occurred on the highest sample rate; failures at lower sample rates were silently ignored. All the instances recorded on the confluence page tracking failures for issue 134 occur at the highest sample rate for the config being tested.

I think we can now expect failures to occur more often and at all sample rates, matching the expectation from the glitches in analogue input testing.