### PR TITLE
Updates to board setup for app_usb_aud_316_mc

### DIFF
--- a/app_usb_aud_xk_316_mc/src/extensions/audiohw.xc
+++ b/app_usb_aud_xk_316_mc/src/extensions/audiohw.xc
@@ -442,11 +442,11 @@ void AudioHwInit()
     if(I2S_LOOPBACK)
     {
 
-        WriteAllAdcRegs(PCM1865_RESET, 0xFE);           //Reset all ADC registers.
-        WriteAllAdcRegs(PCM1865_PWR_STATE, 0x77);       //Sets ADCs into powerdown.
-        WriteAllAdcRegs(PCM1865_FMT, 0x47);             //Sets TDM mode.
-        WriteAllAdcRegs(PCM1865_TX_TDM_OFFSET, 0x42);   //Sets TX_TDM_OFFSET to 66.
-
+        WriteAllAdcRegs(PCM1865_RESET, 0xFE);           // Reset all ADC registers.
+        WriteAllAdcRegs(PCM1865_PWR_STATE, 0x77);       // Sets ADCs into powerdown.
+        WriteAllAdcRegs(PCM1865_FMT, 0b01010011);       // Sets 1/256 TDM mode, 32bit TX_WLEN
+        WriteAllAdcRegs(PCM1865_TX_TDM_OFFSET, 191);    // Sets TX_TDM_OFFSET to 191
+                                                        // Note, expect ADCs to clash with DAC channels 7/8 in loopback TDM mode
         WriteAllDacRegs(PMC5122_DE_SDOUT, 0x01);
         WriteAllDacRegs(PCM5122_GPIO_OUT_SEL, 0x07);
         WriteAllDacRegs(PMC5122_GPIO_ENABLE, 0x20);

--- a/app_usb_aud_xk_316_mc/src/extensions/audiohw.xc
+++ b/app_usb_aud_xk_316_mc/src/extensions/audiohw.xc
@@ -439,20 +439,18 @@ void AudioHwInit()
             assert(result == I2C_REGOP_SUCCESS && msg("DAC I2C write reg failed"));
         }
     }
+
     if(I2S_LOOPBACK)
     {
-
         WriteAllAdcRegs(PCM1865_RESET, 0xFE);           // Reset all ADC registers.
         WriteAllAdcRegs(PCM1865_PWR_STATE, 0x77);       // Sets ADCs into powerdown.
         WriteAllAdcRegs(PCM1865_FMT, 0b01010011);       // Sets 1/256 TDM mode, 32bit TX_WLEN
         WriteAllAdcRegs(PCM1865_TX_TDM_OFFSET, 191);    // Sets TX_TDM_OFFSET to 191
                                                         // Note, expect ADCs to clash with DAC channels 7/8 in loopback TDM mode
-        /* Power down ADC's - sequence from 11.5.3 */
-        WriteAllAdcRegs( 0x00, 0x00);  // Select page0
-        WriteAllAdcRegs(0x70, 0x72);   // Enter sleep mode
-        WriteAllAdcRegs(0x00, 0xfd);   // Select page253
-        WriteAllAdcRegs(0x14, 0x10);   // Change global bias current
-        WriteAllAdcRegs(0x00, 0x00);   //Select page0
+
+        WriteAllDacRegs(PMC5122_DE_SDOUT, 0x01);
+        WriteAllDacRegs(PCM5122_GPIO_OUT_SEL, 0x07);
+        WriteAllDacRegs(PMC5122_GPIO_ENABLE, 0x20);
     }
 }
 

--- a/app_usb_aud_xk_316_mc/src/extensions/audiohw.xc
+++ b/app_usb_aud_xk_316_mc/src/extensions/audiohw.xc
@@ -447,11 +447,13 @@ void AudioHwInit()
         WriteAllAdcRegs(PCM1865_FMT, 0b01010011);       // Sets 1/256 TDM mode, 32bit TX_WLEN
         WriteAllAdcRegs(PCM1865_TX_TDM_OFFSET, 191);    // Sets TX_TDM_OFFSET to 191
                                                         // Note, expect ADCs to clash with DAC channels 7/8 in loopback TDM mode
-        WriteAllDacRegs(PMC5122_DE_SDOUT, 0x01);
-        WriteAllDacRegs(PCM5122_GPIO_OUT_SEL, 0x07);
-        WriteAllDacRegs(PMC5122_GPIO_ENABLE, 0x20);
+        /* Power down ADC's - sequence from 11.5.3 */
+        WriteAllAdcRegs( 0x00, 0x00);  // Select page0
+        WriteAllAdcRegs(0x70, 0x72);   // Enter sleep mode
+        WriteAllAdcRegs(0x00, 0xfd);   // Select page253
+        WriteAllAdcRegs(0x14, 0x10);   // Change global bias current
+        WriteAllAdcRegs(0x00, 0x00);   //Select page0
     }
-
 }
 
 /* Configures the external audio hardware for the required sample frequency */

--- a/app_usb_aud_xk_316_mc/src/extensions/user_main.h
+++ b/app_usb_aud_xk_316_mc/src/extensions/user_main.h
@@ -1,5 +1,5 @@
-#ifndef USER_MAIN_H
-#define USER_MAIN_H
+#ifndef _USER_MAIN_H_
+#define _USER_MAIN_H_
 
 #ifdef __XC__
 
@@ -10,7 +10,7 @@
 
 extern unsafe client interface i2c_master_if i_i2c_client;
 extern void interface_saver(client interface i2c_master_if i);
-extern void ctrlPort();
+extern void board_setup();
 
 /* I2C interface ports */
 extern port p_scl;
@@ -20,7 +20,7 @@ extern port p_sda;
     interface i2c_master_if i2c[1];
 
 #define USER_MAIN_CORES on tile[0]: {\
-                                        ctrlPort();\
+                                        board_setup();\
                                         i2c_master(i2c, 1, p_scl, p_sda, 100);\
                                     }\
                         on tile[1]: {\


### PR DESCRIPTION
- Ensure 1v0 voltage is set appropriately
- Remove potential contention from control port
- Remove ‘soft-start’ of 3v3 as required on 1v0 hardware
- Function rename since now deals with more than just ctrl port

(will squash)