### PR TITLE
Store an artifact of the sandbox manifest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,6 +98,7 @@ pipeline {
                 withEnv(["XMOS_CMAKE_PATH=${WORKSPACE}/xcommon_cmake"]) {
                   sh "cmake -G 'Unix Makefiles' -B build -D BUILD_TESTED_CONFIGS=TRUE"
                   sh "xmake -C build -j16"
+                  archiveArtifacts artifacts: "build/manifest.txt", fingerprint: true, allowEmptyArchive: false
                 }
               }
             }


### PR DESCRIPTION
I forgot to do this in the larger pull request to add XCommon CMake support.