### PR TITLE
Improve reliability of starting the audio analyzer

### DIFF
--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -96,7 +96,7 @@ def test_analogue_input(pytestconfig, board, config):
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
-        AudioAnalyzerHarness(adapter_harness) as harness,
+        AudioAnalyzerHarness(adapter_harness),
     ):
         for fs in features["samp_freqs"]:
             with XsigInput(fs, duration, xsig_config_path, dut.dev_name, ident=f"analogue_input-{board}-{config}-{fs}") as xsig_proc:
@@ -114,10 +114,6 @@ def test_analogue_input(pytestconfig, board, config):
                 fail_str += "\n".join(xsig_lines) + "\n\n"
 
     if len(fail_str) > 0:
-        harness_output = harness.get_output()
-        if len(harness_output) > 0:
-            fail_str += "Audio analyzer stdout\n"
-            fail_str += "\n".join(harness_output)
         pytest.fail(fail_str)
 
 

--- a/tests/test_mixer_ctrl.py
+++ b/tests/test_mixer_ctrl.py
@@ -54,7 +54,7 @@ def test_routing_ctrl_input(pytestconfig, ctrl_app, board, config):
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
-        AudioAnalyzerHarness(adapter_harness) as harness,
+        AudioAnalyzerHarness(adapter_harness),
     ):
 
         # Route analogue inputs 0, 1, ..., N to host inputs N, N-1, ..., 0 respectively
@@ -75,10 +75,6 @@ def test_routing_ctrl_input(pytestconfig, ctrl_app, board, config):
         fail_str += "\n".join(failures) + "\n\n"
         fail_str += "xsig stdout\n"
         fail_str += "\n".join(xsig_lines)
-        harness_output = harness.get_output()
-        if len(harness_output) > 0:
-            fail_str += "\n\nAudio analyzer stdout\n"
-            fail_str += "\n".join(harness_output)
         pytest.fail(fail_str)
 
 
@@ -139,7 +135,7 @@ def test_mixing_ctrl_input(pytestconfig, ctrl_app, board, config):
 
     with (
         XrunDut(adapter_dut, board, config) as dut,
-        AudioAnalyzerHarness(adapter_harness) as harness,
+        AudioAnalyzerHarness(adapter_harness),
     ):
 
         num_mixes = 8
@@ -172,10 +168,6 @@ def test_mixing_ctrl_input(pytestconfig, ctrl_app, board, config):
         fail_str += "\n".join(failures) + "\n\n"
         fail_str += "xsig stdout\n"
         fail_str += "\n".join(xsig_lines)
-        harness_output = harness.get_output()
-        if len(harness_output) > 0:
-            fail_str += "\n\nAudio analyzer stdout\n"
-            fail_str += "\n".join(harness_output)
         pytest.fail(fail_str)
 
 


### PR DESCRIPTION
The xrun command to launch the audio analyzer firmware is run using a Python subprocess, which means that the execution flow returns to the Python test script before we know that the audio analyzer is running. This is necessary for cases where we attach via xscope, as we need the analyzer output to determine the test result. But for cases where the output is not needed (input tests where we just need the analyzer to generate signals), it is more robust to block until the xrun command completes by using subprocess.run(). There are test cases that didn't connect via xscope but still tried to print out the output from the analyzer when the test failed - these were not useful because there is no analyzer output when we don't attach with xscope.