### PR TITLE
Pin dependency versions to released tags

### DIFF
--- a/app_usb_aud_xk_evk_xu316_extrai2s/CMakeLists.txt
+++ b/app_usb_aud_xk_evk_xu316_extrai2s/CMakeLists.txt
@@ -4,7 +4,7 @@ project(app_usb_aud_xk_evk_xu316_extrai2s)
 
 set(APP_HW_TARGET XK-EVK-XU316)
 include(${CMAKE_CURRENT_LIST_DIR}/../deps.cmake)
-list(APPEND APP_DEPENDENT_MODULES "lib_i2s")
+list(APPEND APP_DEPENDENT_MODULES "lib_i2s(5.1.0)")
 set(APP_PCA_ENABLE ON)
 set(SW_USB_AUDIO_FLAGS ${EXTRA_BUILD_FLAGS} -fcomment-asm
                                             -Wall

--- a/deps.cmake
+++ b/deps.cmake
@@ -1,2 +1,2 @@
-set(APP_DEPENDENT_MODULES "xmos/lib_xua"
-                          "lib_i2c")
+set(APP_DEPENDENT_MODULES "lib_xua"
+                          "lib_i2c(6.2.0)")


### PR DESCRIPTION
Pin the versions of lib_i2c and lib_i2s now that they have been released.