### PR TITLE
Fix Python error in test analyzer output parsing

### DIFF
--- a/tests/usb_audio_test_utils.py
+++ b/tests/usb_audio_test_utils.py
@@ -207,7 +207,8 @@ def check_analyzer_output(analyzer_output, xsig_config):
 
         elif channel_config[0] == "zero":
             if len(analyzer_channels[idx]):
-                failures.append(analyzer_channels[idx])
+                for line in analyzer_channels[idx]:
+                    failures.append(line)
 
         else:
             failures.append(f"Invalid channel config {channel_config}")


### PR DESCRIPTION
Have seen a Python exception in the nightly run: `TypeError: sequence item 4: expected str instance, list found`

Based on where the exception is raised, the list returned from the `failures` variable in `check_analyzer_output` contains a list, rather than just strings as was intended. The `analyzer_channels[idx]` is a list of lines of output related to a single audio channel, so these should be appended as individual lines rather than a single list object.

I can't see how any of the other items appended to the `failures` list can be lists instead of strings, so I think this is the root cause of this exception.