### PR TITLE
Use head of develop branch from lib_xua

### DIFF
--- a/deps.cmake
+++ b/deps.cmake
@@ -1,3 +1,3 @@
-set(APP_DEPENDENT_MODULES "lib_xua(4.0.0)"
+set(APP_DEPENDENT_MODULES "lib_xua(develop)"
                           "lib_i2c(6.2.0)"
                           "lib_i2s(5.1.0)")


### PR DESCRIPTION
There has been at least one non-test-related change (https://github.com/xmos/lib_xua/issues/375) in the lib_xua source so we should start regression testing this.