### PR TITLE
XN file updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 sw_usb_audio Change Log
 =======================
 
+UNRELEASED
+----------
+
+  * FIXED:     Use correct number of flash pages for XK-AUDIO-316-MC
+
 8.0.0
 -----
 

--- a/app_usb_aud_xk_316_mc/src/core/xk-audio-316-mc.xn
+++ b/app_usb_aud_xk_316_mc/src/core/xk-audio-316-mc.xn
@@ -10,7 +10,7 @@
   </Declarations>
 
   <Packages>
-    <Package id="0" Type="XS3-UnA-1024-FB265">
+    <Package id="0" Type="XS3-UnA-1024-TQ128">
       <Nodes>
         <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
           <Boot>

--- a/app_usb_aud_xk_316_mc/src/core/xk-audio-316-mc.xn
+++ b/app_usb_aud_xk_316_mc/src/core/xk-audio-316-mc.xn
@@ -80,7 +80,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="8192">
+      <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="16384">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>


### PR DESCRIPTION
Two fixes in the XN file for XK-AUDIO-316-MC:
- the number of flash pages was incorrect for the flash part on the board; with this change I can flash the board without xflash warning about a mismatch between the SFDP value and the override value from the XN file (using internal 15.3 tools build)
- set the package type to TQ128: this is just for correctness in the XN file, but it means that tools 15.1.4 is no longer supported and 15.2.1 is required as the minimum.