### PR TITLE
Set stream format

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def parse_features(board, config):
     for k in ["midi", "spdif_i", "spdif_o", "adat_i", "adat_o", "dsd", "tdm8"]:
         features[k] = features[k] not in ["", "x"]
 
-    if not features["uac"] in [1, 2]:
+    if features["uac"] not in [1, 2]:
         pytest.exit(f"Error: Invalid UAC in {config}")
 
     if board == "xk_216_mc":
@@ -62,7 +62,7 @@ def parse_features(board, config):
         if config.startswith("1"):
             features["pid"] = 0x17
         else:
-            features["pid"] = 0x16 if not "_winbuiltin" in config else 0x1a
+            features["pid"] = 0x16 if "_winbuiltin" not in config else 0x1a
     elif board == "xk_evk_xu316":
         if config.startswith("1"):
             features["pid"] = 0x19

--- a/tests/test_adat.py
+++ b/tests/test_adat.py
@@ -1,21 +1,15 @@
 # Copyright (c) 2022, XMOS Ltd, All rights reserved
 from pathlib import Path
 import pytest
-import subprocess
 import time
 import json
-import platform
 
 from usb_audio_test_utils import (
     check_analyzer_output,
     get_xtag_dut_and_harness,
-    get_volcontrol_path,
-    get_xscope_controller_path,
-    get_tusb_guid,
     stream_format_setup,
     AudioAnalyzerHarness,
     XrunDut,
-    XsigInput,
     XsigOutput,
 )
 from conftest import list_configs, get_config_features

--- a/tests/test_adat.py
+++ b/tests/test_adat.py
@@ -12,6 +12,7 @@ from usb_audio_test_utils import (
     get_volcontrol_path,
     get_xscope_controller_path,
     get_tusb_guid,
+    stream_format_setup,
     AudioAnalyzerHarness,
     XrunDut,
     XsigInput,
@@ -68,6 +69,7 @@ def test_adat_output(pytestconfig, board, config):
     fs_adat = [fs for fs in features["samp_freqs"] if fs <= 48000]
     with XrunDut(adapter_dut, board, config) as dut:
         for fs in fs_adat:
+            stream_format_setup("output", fs, features["chan_o"], 24)
             with (
                 AudioAnalyzerHarness(
                     adapter_harness, config="adat_test", xscope="io"

--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -8,6 +8,7 @@ import platform
 from usb_audio_test_utils import (
     check_analyzer_output,
     get_xtag_dut_and_harness,
+    stream_format_setup,
     AudioAnalyzerHarness,
     XrunDut,
     XsigInput,
@@ -99,6 +100,7 @@ def test_analogue_input(pytestconfig, board, config):
         AudioAnalyzerHarness(adapter_harness),
     ):
         for fs in features["samp_freqs"]:
+            stream_format_setup("input", fs, features["chan_i"], 24)
             with XsigInput(fs, duration, xsig_config_path, dut.dev_name, ident=f"analogue_input-{board}-{config}-{fs}") as xsig_proc:
                 # Sleep for a few extra seconds so that xsig will have completed
                 time.sleep(duration + 6)
@@ -145,6 +147,8 @@ def test_analogue_output(pytestconfig, board, config):
                 and fs in [44100, 48000]
             ):
                 continue
+
+            stream_format_setup("output", fs, features["chan_o"], 24)
 
             with (
                 AudioAnalyzerHarness(adapter_harness, xscope="io") as harness,

--- a/tests/test_dfu.py
+++ b/tests/test_dfu.py
@@ -4,7 +4,6 @@ import platform
 import pytest
 import subprocess
 import time
-import tempfile
 import os
 import re
 import stat

--- a/tests/test_loopback.py
+++ b/tests/test_loopback.py
@@ -8,6 +8,7 @@ import platform
 from usb_audio_test_utils import (
     check_analyzer_output,
     get_xtag_dut,
+    stream_format_setup,
     XrunDut,
     XsigInput,
 )
@@ -72,6 +73,10 @@ def test_loopback_dac(pytestconfig, board, config):
                 and fs in [44100, 48000]
             ):
                 continue
+
+            stream_format_setup("input", fs, features["chan_i"], 24)
+            stream_format_setup("output", fs, features["chan_o"], 24)
+
             with XsigInput(fs, duration, xsig_config_path, dut.dev_name) as xsig_proc:
                 time.sleep(duration + 6)
                 xsig_lines = xsig_proc.get_output()

--- a/tests/test_mixer_ctrl.py
+++ b/tests/test_mixer_ctrl.py
@@ -9,6 +9,7 @@ from usb_audio_test_utils import (
     check_analyzer_output,
     get_xtag_dut_and_harness,
     get_tusb_guid,
+    stream_format_setup,
     AudioAnalyzerHarness,
     XrunDut,
     XsigInput,
@@ -61,6 +62,8 @@ def test_routing_ctrl_input(pytestconfig, ctrl_app, board, config):
         XrunDut(adapter_dut, board, config) as dut,
         AudioAnalyzerHarness(adapter_harness),
     ):
+        stream_format_setup("input", fs, features["chan_i"], 24)
+
         # Route analogue inputs 0, 1, ..., N to host inputs N, N-1, ..., 0 respectively
         num_chans = features["analogue_i"]
         for ch in range(num_chans):
@@ -104,6 +107,8 @@ def test_routing_ctrl_output(pytestconfig, ctrl_app, board, config):
         XrunDut(adapter_dut, board, config) as dut,
         AudioAnalyzerHarness(adapter_harness, xscope="io") as harness,
     ):
+        stream_format_setup("output", fs, features["chan_o"], 24)
+
         # Route host outputs 0, 1, ..., N to analogue outputs N, N-1, ..., 0 respectively
         num_chans = features["analogue_o"]
         for ch in range(num_chans):
@@ -150,6 +155,8 @@ def test_mixing_ctrl_input(pytestconfig, ctrl_app, board, config):
         XrunDut(adapter_dut, board, config) as dut,
         AudioAnalyzerHarness(adapter_harness),
     ):
+        stream_format_setup("input", fs, features["chan_i"], 24)
+
         num_mixes = 8
         num_chans = features["analogue_i"]
         if num_chans > num_mixes:
@@ -217,6 +224,8 @@ def test_mixing_ctrl_output(pytestconfig, ctrl_app, board, config):
         XrunDut(adapter_dut, board, config) as dut,
         AudioAnalyzerHarness(adapter_harness, xscope="io") as harness,
     ):
+        stream_format_setup("output", fs, features["chan_o"], 24)
+
         num_mixes = 8
         num_chans = features["analogue_o"]
         if num_chans > num_mixes:
@@ -284,6 +293,8 @@ def test_mixing_multi_channel_output(pytestconfig, ctrl_app, board, config):
         XrunDut(adapter_dut, board, config) as dut,
         AudioAnalyzerHarness(adapter_harness, xscope="io") as harness,
     ):
+        stream_format_setup("output", fs, features["chan_o"], 24)
+
         num_mixes = 8
         num_chans = features["analogue_o"]
         if num_chans > num_mixes:
@@ -364,6 +375,8 @@ def test_routing_daw_out_mix_input(pytestconfig, ctrl_app, board, config):
         XrunDut(adapter_dut, board, config) as dut,
         AudioAnalyzerHarness(adapter_harness, xscope="io") as harness,
     ):
+        stream_format_setup("output", fs, features["chan_o"], 24)
+
         num_mixes = 8
         num_chans = features["analogue_i"]
         if num_chans > num_mixes:

--- a/tests/test_spdif.py
+++ b/tests/test_spdif.py
@@ -12,6 +12,7 @@ from usb_audio_test_utils import (
     get_volcontrol_path,
     get_xscope_controller_path,
     get_tusb_guid,
+    stream_format_setup,
     AudioAnalyzerHarness,
     XrunDut,
     XsigInput,
@@ -86,6 +87,8 @@ def test_spdif_input(pytestconfig, board, config):
 
     with XrunDut(adapter_dut, board, config) as dut:
         for fs in features["samp_freqs"]:
+            stream_format_setup("input", fs, features["chan_i"], 24)
+
             with AudioAnalyzerHarness(
                 adapter_harness, config="spdif_test", xscope="app"
             ) as harness:
@@ -153,6 +156,8 @@ def test_spdif_output(pytestconfig, board, config):
 
     with XrunDut(adapter_dut, board, config) as dut:
         for fs in features["samp_freqs"]:
+            stream_format_setup("output", fs, features["chan_o"], 24)
+
             with (
                 AudioAnalyzerHarness(
                     adapter_harness, config="spdif_test", xscope="io"

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -13,6 +13,7 @@ from usb_audio_test_utils import (
     get_volcontrol_path,
     get_xscope_controller_path,
     get_tusb_guid,
+    stream_format_setup,
     AudioAnalyzerHarness,
     XrunDut,
     XsigInput,
@@ -81,6 +82,8 @@ def test_volume_input(pytestconfig, board, config):
         XrunDut(adapter_dut, board, config) as dut,
         AudioAnalyzerHarness(adapter_harness),
     ):
+        stream_format_setup("input", fs, features["chan_i"], 24)
+
         for channel in test_chans:
             channels = range(num_chans) if channel == "m" else [channel]
 
@@ -156,6 +159,8 @@ def test_volume_output(pytestconfig, board, config):
     fail_str = ""
 
     with XrunDut(adapter_dut, board, config) as dut:
+        stream_format_setup("output", fs, features["chan_o"], 24)
+
         for channel in test_chans:
             channels = range(num_chans) if channel == "m" else [channel]
 

--- a/tests/tools/volcontrol/volcontrol.cpp
+++ b/tests/tools/volcontrol/volcontrol.cpp
@@ -13,6 +13,9 @@ struct volcontrol {
   int channel_index;
   float volume;
   uint32_t clock_src;
+  int sample_rate;
+  unsigned num_chans;
+  unsigned bit_depth;
 #ifdef _WIN32
   TCHAR driver_guid[GUID_STR_LEN];
 #endif
@@ -25,6 +28,7 @@ void help(void) {
     printf("  --set [input|output] channel_index volume   Set volume of channel index\n");
     printf("  --showall                    Show all volumes\n");
     printf("  --clock < \"Internal\" | \"SPDIF\" | \"ADAT\" >\n");
+    printf("  --set-format [input|output] <sample-rate> <num-channels> <bit-depth>\n");
 #ifdef _WIN32
     printf("  -g<GUID>      Driver GUID string, eg. -g{E5A2658B-817D-4A02-A1DE-B628A93DDF5D}\n");
 #endif
@@ -129,6 +133,46 @@ int main(int argc, char const* argv[])
             }
             ++i;
         }
+        else if (strcmp(argv[i], "--set-format") == 0) {
+            ++i;
+            v.op = SET_STREAM_FORMAT;
+            if (i >= argc) {
+                help();
+            }
+
+            if (strcmp(argv[i], "input") == 0) {
+                ++i;
+                v.scope = ScopeInput;
+            }
+            else if (strcmp(argv[i], "output") == 0) {
+                ++i;
+                v.scope = ScopeOutput;
+            }
+            else {
+                help();
+            }
+
+            if (i >= argc) {
+                help();
+            }
+
+            v.sample_rate = atoi(argv[i]);
+            ++i;
+
+            if (i >= argc) {
+                help();
+            }
+
+            v.num_chans = atoi(argv[i]);
+            ++i;
+
+            if (i >= argc) {
+                help();
+            }
+
+            v.bit_depth = atoi(argv[i]);
+            ++i;
+        }
 #ifdef _WIN32
         else if (strncmp(argv[i], "-g", 2) == 0) {
             const char *str_ptr;
@@ -179,6 +223,10 @@ int main(int argc, char const* argv[])
 
         case SET_CLOCK:
             setClock(deviceID, v.clock_src);
+            break;
+
+        case SET_STREAM_FORMAT:
+            setStreamFormat(deviceID, v.scope, v.sample_rate, v.num_chans, v.bit_depth);
             break;
     }
 

--- a/tests/tools/volcontrol/volcontrol.h
+++ b/tests/tools/volcontrol/volcontrol.h
@@ -8,7 +8,8 @@ enum operation {
   RESET_ALL,
   SET_VOLUME,
   SHOW_ALL,
-  SET_CLOCK
+  SET_CLOCK,
+  SET_STREAM_FORMAT,
 };
 
 enum scope {
@@ -31,6 +32,8 @@ void setVolume(AudioDeviceHandle deviceID, uint32_t scope,
 	       uint32_t channel, float volume);
 
 void setClock(AudioDeviceHandle deviceID, uint32_t clockId);
+
+void setStreamFormat(AudioDeviceHandle deviceID, uint32_t scope, int sample_rate, unsigned num_chans, unsigned bit_depth);
 
 void finish(void);
 #endif  // _volcontrol_h_

--- a/tests/usb_audio_test_utils.py
+++ b/tests/usb_audio_test_utils.py
@@ -154,7 +154,7 @@ def check_analyzer_output(analyzer_output, xsig_config):
                 )
                 continue
 
-            initial_volume = int(vol_changes.pop(0))
+            _ = int(vol_changes.pop(0))
             initial_change = int(vol_changes.pop(0))
             if initial_change >= 0:
                 failures.append(
@@ -324,7 +324,7 @@ def get_tusb_guid():
             guid = config.get("DriverInterface", "InterfaceGUID")
             return guid
         except (configparser.NoSectionError, configparser.NoOptionError):
-            pytest.fail(f"Could not find InterfaceGUID in custom.ini")
+            pytest.fail("Could not find InterfaceGUID in custom.ini")
 
 
 def stream_format_setup(direction, samp_freq, num_chans, bit_depth):

--- a/tests/usb_audio_test_utils.py
+++ b/tests/usb_audio_test_utils.py
@@ -327,6 +327,16 @@ def get_tusb_guid():
             pytest.fail(f"Could not find InterfaceGUID in custom.ini")
 
 
+def stream_format_setup(direction, samp_freq, num_chans, bit_depth):
+    cmd = [get_volcontrol_path()]
+    if platform.system() == "Windows":
+        cmd.append(f"-g{get_tusb_guid()}")
+    cmd += ["--set-format", direction, f"{samp_freq}", f"{num_chans}", f"{bit_depth}"]
+    ret = subprocess.run(cmd, timeout=30, capture_output=True, text=True)
+    if ret.returncode != 0:
+        pytest.fail(f"failed to setup stream format: {direction}, {samp_freq} fs, {num_chans} channels, {bit_depth} bit\n{ret.stdout}\n{ret.stderr}")
+
+
 class AudioAnalyzerHarness:
     """
     Run the audio analyzer harness


### PR DESCRIPTION
Added option in volcontrol to set the stream format. This is supported on Windows and MacOS. Windows sets it based on the number of channels and bit depth; MacOS also requires the sample rate. This command is run before every test to ensure that the device is setup correctly.