### PR TITLE
Temporarily disable MIDI tests on Windows

### DIFF
--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -29,6 +29,10 @@ def midi_loopback_uncollect(pytestconfig, board, config):
     features = get_config_features(board, config)
     xtag_ids = get_xtag_dut_and_harness(pytestconfig, board)
 
+    # Test can get stuck on Windows, so disable it temporarily
+    if platform.system() == "Windows":
+        return True
+
     # Until we fix Jenkins user permissions for MIDI on Mac https://xmosjira.atlassian.net/browse/UA-254
     if platform.system() == "Darwin":
         return True

--- a/tests/test_midi_stress.py
+++ b/tests/test_midi_stress.py
@@ -36,6 +36,10 @@ def midi_stress_uncollect(pytestconfig, board, config):
     if not all(xtag_ids):
         return True
 
+    # Test can get stuck on Windows, so disable it temporarily
+    if platform.system() == "Windows":
+        return True
+
     # Until we fix Jenkins user permissions for MIDI on Mac https://xmosjira.atlassian.net/browse/UA-254
     if platform.system() == "Darwin":
         return True


### PR DESCRIPTION
If we don't have a solution for the MIDI tests getting stuck, temporarily disable them.