### PR TITLE
Review test levels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,7 +201,7 @@ pipeline {
 
                       withXTAG(["usb_audio_mc_xs2_dut", "usb_audio_mc_xs2_harness", \
                                 "usb_audio_xcai_exp_dut", "usb_audio_xcai_exp_harness"]) { xtagIds ->
-                        sh "pytest -s -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_intel.xml \
+                        sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_intel.xml \
                             -o xk_216_mc_dut=${xtagIds[0]} -o xk_216_mc_harness=${xtagIds[1]} \
                             -o xk_evk_xu316_dut=${xtagIds[2]} -o xk_evk_xu316_harness=${xtagIds[3]}"
                       }
@@ -263,7 +263,7 @@ pipeline {
                       sh "pip install -e ${WORKSPACE}/xtagctl"
 
                       withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
-                        sh "pytest -s -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_arm.xml \
+                        sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_arm.xml \
                             -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]}"
                       }
                     }
@@ -330,7 +330,7 @@ pipeline {
                       sh "pip install -e ."
                     }
                     withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
-                      sh "pytest -s -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_windows10.xml \
+                      sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_windows10.xml \
                           -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]}"
                     }
                   }
@@ -397,7 +397,7 @@ pipeline {
                     }
 
                     withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
-                      sh "pytest -s -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_windows11.xml \
+                      sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_windows11.xml \
                           -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]}"
                     }
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -285,6 +285,12 @@ pipeline {
         }  // MacOS ARM
 
         stage('Windows 10') {
+          when {
+            expression {
+              params.TEST_LEVEL == "nightly" ||
+              params.TEST_LEVEL == "weekend"
+            }
+          }
           agent {
             label 'usb_audio && windows10 && xcore.ai-mcab'
           }
@@ -345,6 +351,12 @@ pipeline {
         }  // Windows 10
 
         stage('Windows 11') {
+          when {
+            expression {
+              params.TEST_LEVEL == "nightly" ||
+              params.TEST_LEVEL == "weekend"
+            }
+          }
           agent {
             label 'usb_audio && windows11 && xcore.ai-mcab'
           }

--- a/app_usb_aud_xk_216_mc/CMakeLists.txt
+++ b/app_usb_aud_xk_216_mc/CMakeLists.txt
@@ -14,8 +14,6 @@ set(SW_USB_AUDIO_FLAGS ${EXTRA_BUILD_FLAGS} -O3
                                             -DADAT_TX_USE_SHARED_BUFF=1
                                             -DXUA_QUAD_SPI_FLASH=1)
 
-set(APP_COMPILER_FLAGS_1AMi2o2xxxxxx ${SW_USB_AUDIO_FLAGS} -DAUDIO_CLASS=1)
-
 set(APP_COMPILER_FLAGS_2AMi10o10xssxxx ${SW_USB_AUDIO_FLAGS} -DXUA_SPDIF_TX_EN=1
                                                              -DXUA_SPDIF_RX_EN=1)
 
@@ -25,15 +23,6 @@ set(APP_COMPILER_FLAGS_2ASi10o10xssxxx ${SW_USB_AUDIO_FLAGS} -DXUA_SPDIF_TX_EN=1
 
 set(APP_COMPILER_FLAGS_2AMi8o10mxsxxx ${SW_USB_AUDIO_FLAGS} -DMIDI=1
                                                             -DXUA_SPDIF_TX_EN=1)
-
-set(APP_COMPILER_FLAGS_2ASi16o16xxxxxx_tdm8 ${SW_USB_AUDIO_FLAGS} -DI2S_CHANS_ADC=16
-                                                                  -DI2S_CHANS_DAC=16
-                                                                  -DNUM_USB_CHAN_IN=16
-                                                                  -DNUM_USB_CHAN_OUT=16
-                                                                  -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM
-                                                                  -DMAX_FREQ=96000
-                                                                  -DCODEC_MASTER=1
-                                                                  -DOUT_VOLUME_IN_MIXER=0)
 
 set(APP_COMPILER_FLAGS_2AMi16o16xxxaax ${SW_USB_AUDIO_FLAGS} -DXUA_ADAT_RX_EN=1 -DXUA_ADAT_TX_EN=1)
 

--- a/app_usb_aud_xk_216_mc/Makefile
+++ b/app_usb_aud_xk_216_mc/Makefile
@@ -32,10 +32,6 @@ USED_MODULES = lib_xua lib_i2c
 
 # Fully tested build configs (Note these make use of the defaults in xua_conf.h)
 
-# Audio Class 1, I2S Master, 2xInput, 2xOutput
-INCLUDE_ONLY_IN_1AMi2o2xxxxxx =
-XCC_FLAGS_1AMi2o2xxxxxx = $(BUILD_FLAGS)        -DAUDIO_CLASS=1
-
 # Audio Class 2, I2S Master, 10xInput, 10xOutput, S/PDIF Rx, S/PDIF Tx
 INCLUDE_ONLY_IN_2AMi10o10xssxxx =
 XCC_FLAGS_2AMi10o10xssxxx = $(BUILD_FLAGS)      -DXUA_SPDIF_RX_EN=1 \
@@ -51,18 +47,6 @@ XCC_FLAGS_2ASi10o10xssxxx = $(BUILD_FLAGS)      -DXUA_SPDIF_RX_EN=1 \
 INCLUDE_ONLY_IN_2AMi8o10mxsxxx =
 XCC_FLAGS_2AMi8o10mxsxxx = $(BUILD_FLAGS) 		-DMIDI=1 \
 												-DXUA_SPDIF_TX_EN=1
-
-# Audio Class 2, Async, I2S Slave, 16xInput 16xOutput (TDM)
-# Note, TDM requires more MIPs than I2S so we do volume processin in the decouple task
-INCLUDE_ONLY_IN_2ASi16o16xxxxxx_tdm8 =
-XCC_FLAGS_2ASi16o16xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=16 \
-                                                -DI2S_CHANS_DAC=16 \
-                                                -DNUM_USB_CHAN_IN=16 \
-                                                -DNUM_USB_CHAN_OUT=16 \
-                                                -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
-                                                -DMAX_FREQ=96000 \
-                                                -DCODEC_MASTER=1 \
-                                                -DOUT_VOLUME_IN_MIXER=0
 
 # Audio Class 2, Async, I2S Master, 16xInput, 16xOutput, ADAT Tx, ADAT Rx
 INCLUDE_ONLY_IN_2AMi16o16xxxaax =

--- a/app_usb_aud_xk_216_mc/configs_build.cmake
+++ b/app_usb_aud_xk_216_mc/configs_build.cmake
@@ -14,8 +14,6 @@ set(APP_COMPILER_FLAGS_2AXi0o2xxsxxx ${SW_USB_AUDIO_FLAGS} -DXUA_SPDIF_TX_EN=1
 
 set(APP_COMPILER_FLAGS_2AMi32o32xxxxxx_tdm8 ${SW_USB_AUDIO_FLAGS} -DI2S_CHANS_ADC=32
                                                                   -DI2S_CHANS_DAC=32
-                                                                  -DNUM_USB_CHAN_IN=32
-                                                                  -DNUM_USB_CHAN_OUT=32
                                                                   -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM
                                                                   -DMAX_FREQ=48000)
 
@@ -26,8 +24,6 @@ set(APP_COMPILER_FLAGS_2ASi0o8xxxxxx_tdm8 ${SW_USB_AUDIO_FLAGS} -DI2S_CHANS_ADC=
 
 set(APP_COMPILER_FLAGS_2AMi16o16xxxxxx_tdm8 ${SW_USB_AUDIO_FLAGS} -DI2S_CHANS_DAC=16
                                                                   -DI2S_CHANS_ADC=16
-                                                                  -DNUM_USB_CHAN_IN=16
-                                                                  -DNUM_USB_CHAN_OUT=16
                                                                   -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM
                                                                   -DMAX_FREQ=96000)
 

--- a/app_usb_aud_xk_216_mc/configs_build.inc
+++ b/app_usb_aud_xk_216_mc/configs_build.inc
@@ -28,40 +28,12 @@ XCC_FLAGS_2AMi32o32xxxxxx_tdm8  = $(BUILD_FLAGS) -DI2S_CHANS_DAC=32 \
                                                 -DMAX_FREQ=48000
 INCLUDE_ONLY_IN_2AMi32o32xxxxxx_tdm8 =
 
-# Audio Class 2, Async, I2S Master, 32xInput, 32xOutput, S/PDIF Tx, TDM
-XCC_FLAGS_2AMi32o32xxsxxx_tdm8 = $(BUILD_FLAGS) -DXUA_SPDIF_TX_EN=1 \
-                                                -DI2S_CHANS_ADC=32 \
-                                                -DI2S_CHANS_DAC=32 \
-                                                -DNUM_USB_CHAN_OUT=32 \
-                                                -DNUM_USB_CHAN_IN=32 \
-                                                -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
-                                                -DMAX_FREQ=48000
-INCLUDE_ONLY_IN_2AMi32o32xxsxxx_tdm8 =
-
-# Audio Class 2, Async, I2S Master, 32xInput 32xOutput (TDM)
-INCLUDE_ONLY_IN_2AMi32o32xxxxxx_tdm8 =
-XCC_FLAGS_2AMi32o32xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=32 \
-                                                -DI2S_CHANS_DAC=32 \
-                                                -DNUM_USB_CHAN_IN=32 \
-                                                -DNUM_USB_CHAN_OUT=32 \
-                                                -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
-                                                -DMAX_FREQ=48000
-
 # Audio Class 2, Async, I2S Slave, 0xInput, 8xOutput, TDM
 XCC_FLAGS_2ASi0o8xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=0 \
                                               -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
                                               -DMAX_FREQ=96000 \
                                               -DCODEC_MASTER=1
 INCLUDE_ONLY_IN_2ASi0o8xxxxxx_tdm8 =
-
-# Audio Class 2, Async, I2S Master, 16xInput 16xOutput (TDM)
-INCLUDE_ONLY_IN_2AMi16o16xxxxxx_tdm8 =
-XCC_FLAGS_2AMi16o16xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=16 \
-                                                                                                -DI2S_CHANS_DAC=16 \
-                                                                                                -DNUM_USB_CHAN_IN=16 \
-                                                                                                -DNUM_USB_CHAN_OUT=16 \
-                                                                                                -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
-                                                                                                -DMAX_FREQ=96000
 
 # Audio Class 2, Async, I2S Master, 32xInput 32xOutput, S/PDIF Tx (TDM)
 INCLUDE_ONLY_IN_2AMi32o32xxsxxx_tdm8 =

--- a/app_usb_aud_xk_216_mc/configs_partial.cmake
+++ b/app_usb_aud_xk_216_mc/configs_partial.cmake
@@ -10,6 +10,8 @@ endif()
 
 if(PARTIAL_TESTED_CONFIGS)
 
+set(APP_COMPILER_FLAGS_1AMi2o2xxxxxx ${SW_USB_AUDIO_FLAGS} -DAUDIO_CLASS=1)
+
 set(APP_COMPILER_FLAGS_2AMi8o8xxxxxx ${SW_USB_AUDIO_FLAGS})
 
 set(APP_COMPILER_FLAGS_2ASi8o8xxxxxx_tdm8 ${SW_USB_AUDIO_FLAGS} -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM
@@ -34,5 +36,15 @@ set(APP_COMPILER_FLAGS_2SMi8o8xxxxxx ${SW_USB_AUDIO_FLAGS} -DXUA_SYNCMODE=XUA_SY
 set(APP_COMPILER_FLAGS_2AMi16o8xxxaxx ${SW_USB_AUDIO_FLAGS} -DXUA_ADAT_RX_EN=1)
 
 set(APP_COMPILER_FLAGS_2AMi8o16xxxxax ${SW_USB_AUDIO_FLAGS} -DXUA_ADAT_TX_EN=1)
+
+# Note, TDM requires more MIPs than I2S so we do volume processin in the decouple task
+set(APP_COMPILER_FLAGS_2ASi16o16xxxxxx_tdm8 ${SW_USB_AUDIO_FLAGS} -DI2S_CHANS_ADC=16
+                                                                  -DI2S_CHANS_DAC=16
+                                                                  -DNUM_USB_CHAN_IN=16
+                                                                  -DNUM_USB_CHAN_OUT=16
+                                                                  -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM
+                                                                  -DMAX_FREQ=96000
+                                                                  -DCODEC_MASTER=1
+                                                                  -DOUT_VOLUME_IN_MIXER=0)
 
 endif()

--- a/app_usb_aud_xk_216_mc/configs_partial.inc
+++ b/app_usb_aud_xk_216_mc/configs_partial.inc
@@ -1,5 +1,9 @@
 # Configs that have been partially tested, but not as comprehensively as those in the Makefile
 
+# Audio Class 1, I2S Master, 2xInput, 2xOutput
+INCLUDE_ONLY_IN_1AMi2o2xxxxxx =
+XCC_FLAGS_1AMi2o2xxxxxx = $(BUILD_FLAGS)        -DAUDIO_CLASS=1
+
 # Audio Class 2, Async, I2S Master, 8xInput, 8xOutput
 XCC_FLAGS_2AMi8o8xxxxxx = $(BUILD_FLAGS)
 INCLUDE_ONLY_IN_2AMi8o8xxxxxx =
@@ -47,3 +51,14 @@ XCC_FLAGS_2AMi16o8xxxaxx = $(BUILD_FLAGS)       -DXUA_ADAT_RX_EN=1
 INCLUDE_ONLY_IN_2AMi8o16xxxxax =
 XCC_FLAGS_2AMi8o16xxxxax = $(BUILD_FLAGS)       -DXUA_ADAT_TX_EN=1
 
+# Audio Class 2, Async, I2S Slave, 16xInput 16xOutput (TDM)
+# Note, TDM requires more MIPs than I2S so we do volume processin in the decouple task
+INCLUDE_ONLY_IN_2ASi16o16xxxxxx_tdm8 =
+XCC_FLAGS_2ASi16o16xxxxxx_tdm8 = $(BUILD_FLAGS) -DI2S_CHANS_ADC=16 \
+                                                -DI2S_CHANS_DAC=16 \
+                                                -DNUM_USB_CHAN_IN=16 \
+                                                -DNUM_USB_CHAN_OUT=16 \
+                                                -DXUA_PCM_FORMAT=XUA_PCM_FORMAT_TDM \
+                                                -DMAX_FREQ=96000 \
+                                                -DCODEC_MASTER=1 \
+                                                -DOUT_VOLUME_IN_MIXER=0

--- a/app_usb_aud_xk_316_mc/CMakeLists.txt
+++ b/app_usb_aud_xk_316_mc/CMakeLists.txt
@@ -14,11 +14,6 @@ set(SW_USB_AUDIO_FLAGS ${EXTRA_BUILD_FLAGS} -O3
                                             -DADAT_TX_USE_SHARED_BUFF=1
                                             -DXUA_QUAD_SPI_FLASH=1)
 
-set(APP_COMPILER_FLAGS_1AMi2o2xxxxxx ${SW_USB_AUDIO_FLAGS} -DAUDIO_CLASS=1)
-
-set(APP_COMPILER_FLAGS_2AMi2o2xxxxxx ${SW_USB_AUDIO_FLAGS} -DI2S_CHANS_DAC=2
-                                                           -DI2S_CHANS_ADC=2)
-
 set(APP_COMPILER_FLAGS_2AMi8o8xxxxxx ${SW_USB_AUDIO_FLAGS})
 
 set(APP_COMPILER_FLAGS_2AMi8o8xxxxxx_mix8 ${SW_USB_AUDIO_FLAGS} -DMAX_MIX_COUNT=8)

--- a/app_usb_aud_xk_316_mc/Makefile
+++ b/app_usb_aud_xk_316_mc/Makefile
@@ -38,15 +38,6 @@ USED_MODULES = lib_sw_pll lib_xua lib_i2c
 # Asynchronous Mode Configs
 #
 
-# Audio Class 1, Async, I2S Master, 2xInput, 2xOutput
-INCLUDE_ONLY_IN_1AMi2o2xxxxxx =
-XCC_FLAGS_1AMi2o2xxxxxx = $(BUILD_FLAGS)        -DAUDIO_CLASS=1
-
-# Audio Class 2, Async, I2S Master, 2xInput, 2xOutput
-INCLUDE_ONLY_IN_2AMi2o2xxxxxx =
-XCC_FLAGS_2AMi2o2xxxxxx = $(BUILD_FLAGS)        -DI2S_CHANS_DAC=2 \
-                                                -DI2S_CHANS_ADC=2
-
 # Audio Class 2, Async, I2S Master, 8xInput, 8xOutput
 INCLUDE_ONLY_IN_2AMi8o8xxxxxx =
 XCC_FLAGS_2AMi8o8xxxxxx = $(BUILD_FLAGS)
@@ -69,7 +60,7 @@ XCC_FLAGS_2ASi8o8xxxxxx_tdm8 = $(BUILD_FLAGS)   -DCODEC_MASTER=1 \
 
 # Audio Class 2, Async, I2S Master, 8xInput, 8xOutput, MIDI
 INCLUDE_ONLY_IN_2AMi8o8mxxxxx =
-XCC_FLAGS_2AMi8o8mxxxxx = $(BUILD_FLAGS)		-DMIDI=1
+XCC_FLAGS_2AMi8o8mxxxxx = $(BUILD_FLAGS)               -DMIDI=1
 
 # Audio Class 2, Async, I2S Master, 10xInput, 10xOutput, S/PDIF Tx, S/PDIF Rx
 INCLUDE_ONLY_IN_2AMi10o10xssxxx =
@@ -87,11 +78,6 @@ XCC_FLAGS_2AMi18o18mssaax = $(BUILD_FLAGS)      -DMIDI=1 -DXUA_ADAT_TX_EN=1 -DXU
 #
 # Synchronous Mode Configs
 #
-# Audio Class 1, Sync, I2S Master, 2xInput, 2xOutput
-INCLUDE_ONLY_IN_1SMi2o2xxxxxx =
-XCC_FLAGS_1SMi2o2xxxxxx = $(BUILD_FLAGS)        -DAUDIO_CLASS=1 \
-                                                -DXUA_SYNCMODE=XUA_SYNCMODE_SYNC
-
 # Audio Class 2, Sync, I2S Master, 8xInput, 8xOutput
 INCLUDE_ONLY_IN_2SMi8o8xxxxxx =
 XCC_FLAGS_2SMi8o8xxxxxx = $(BUILD_FLAGS)        -DXUA_SYNCMODE=XUA_SYNCMODE_SYNC

--- a/app_usb_aud_xk_316_mc/configs_partial.cmake
+++ b/app_usb_aud_xk_316_mc/configs_partial.cmake
@@ -10,6 +10,13 @@ endif()
 
 if(PARTIAL_TESTED_CONFIGS)
 
+# Audio Class 1, Async, I2S Master, 2xInput, 2xOutput
+set(APP_COMPILER_FLAGS_1AMi2o2xxxxxx ${SW_USB_AUDIO_FLAGS} -DAUDIO_CLASS=1)
+
+# Audio Class 2, Async, I2S Master, 2xInput, 2xOutput
+set(APP_COMPILER_FLAGS_2AMi2o2xxxxxx ${SW_USB_AUDIO_FLAGS} -DI2S_CHANS_DAC=2
+                                                           -DI2S_CHANS_ADC=2)
+
 # Audio Class 2, Async, I2S Slave, 8xInput, 8xOutput
 set(APP_COMPILER_FLAGS_2ASi8o8xxxxxx ${SW_USB_AUDIO_FLAGS} -DCODEC_MASTER=1)
 
@@ -23,6 +30,12 @@ set(APP_COMPILER_FLAGS_2AMi32o32xxxxxx_tdm8 ${SW_USB_AUDIO_FLAGS} -DXUA_PCM_FORM
 
 # Audio Class 2, Async, I2S Master, 8xInput, 10xOutput, S/PDIF Tx
 set(APP_COMPILER_FLAGS_2AMi8o10xxsxxx ${SW_USB_AUDIO_FLAGS} -DXUA_SPDIF_TX_EN=1)
+
+# Audio Class 2, Async, I2S Master, 8xInput, 16xOutput, ADAT Tx
+set(APP_COMPILER_FLAGS_2AMi8o16xxxxax ${SW_USB_AUDIO_FLAGS} -DXUA_ADAT_TX_EN=1)
+
+# Audio Class 2, Async, I2S Master, 16xInput, 8xOutput, ADAT Rx
+set(APP_COMPILER_FLAGS_2AMi16o8xxxaxx ${SW_USB_AUDIO_FLAGS} -DXUA_ADAT_RX_EN=1)
 
 
 # Audio Class 2, Async, I2S Slave, 10xInput, 10xOutput, S/PDIF Tx, S/PDIF Rx

--- a/app_usb_aud_xk_316_mc/configs_partial.cmake
+++ b/app_usb_aud_xk_316_mc/configs_partial.cmake
@@ -31,13 +31,6 @@ set(APP_COMPILER_FLAGS_2AMi32o32xxxxxx_tdm8 ${SW_USB_AUDIO_FLAGS} -DXUA_PCM_FORM
 # Audio Class 2, Async, I2S Master, 8xInput, 10xOutput, S/PDIF Tx
 set(APP_COMPILER_FLAGS_2AMi8o10xxsxxx ${SW_USB_AUDIO_FLAGS} -DXUA_SPDIF_TX_EN=1)
 
-# Audio Class 2, Async, I2S Master, 8xInput, 16xOutput, ADAT Tx
-set(APP_COMPILER_FLAGS_2AMi8o16xxxxax ${SW_USB_AUDIO_FLAGS} -DXUA_ADAT_TX_EN=1)
-
-# Audio Class 2, Async, I2S Master, 16xInput, 8xOutput, ADAT Rx
-set(APP_COMPILER_FLAGS_2AMi16o8xxxaxx ${SW_USB_AUDIO_FLAGS} -DXUA_ADAT_RX_EN=1)
-
-
 # Audio Class 2, Async, I2S Slave, 10xInput, 10xOutput, S/PDIF Tx, S/PDIF Rx
 set(APP_COMPILER_FLAGS_2ASi10o10xssxxx ${SW_USB_AUDIO_FLAGS} -DXUA_SPDIF_TX_EN=1
                                                              -DXUA_SPDIF_RX_EN=1

--- a/app_usb_aud_xk_316_mc/configs_partial.inc
+++ b/app_usb_aud_xk_316_mc/configs_partial.inc
@@ -3,6 +3,15 @@
 #
 # Asynchronous Mode Configs
 #
+# Audio Class 1, Async, I2S Master, 2xInput, 2xOutput
+INCLUDE_ONLY_IN_1AMi2o2xxxxxx =
+XCC_FLAGS_1AMi2o2xxxxxx = $(BUILD_FLAGS)        -DAUDIO_CLASS=1
+
+# Audio Class 2, Async, I2S Master, 2xInput, 2xOutput
+INCLUDE_ONLY_IN_2AMi2o2xxxxxx =
+XCC_FLAGS_2AMi2o2xxxxxx = $(BUILD_FLAGS)        -DI2S_CHANS_DAC=2 \
+                                                -DI2S_CHANS_ADC=2
+
 # Audio Class 2, Async, I2S Master, 8xInput, 8xOutput
 INCLUDE_ONLY_IN_2AMi8o8xxxxxx =
 XCC_FLAGS_2AMi8o8xxxxxx = $(BUILD_FLAGS)
@@ -23,6 +32,14 @@ XCC_FLAGS_2AMi32o32xxxxxx_tdm8 = $(BUILD_FLAGS)	-DXUA_PCM_FORMAT=XUA_PCM_FORMAT_
 # Audio Class 2, Async, I2S Master, 8xInput, 10xOutput, S/PDIF Tx
 INCLUDE_ONLY_IN_2AMi8o10xxsxxx =
 XCC_FLAGS_2AMi8o10xxsxxx = $(BUILD_FLAGS)		-DXUA_SPDIF_TX_EN=1
+
+# Audio Class 2, Async, I2S Master, 16xInput, 8xOutput, ADAT Rx
+INCLUDE_ONLY_IN_2AMi16o8xxxaxx =
+XCC_FLAGS_2AMi16o8xxxaxx = $(BUILD_FLAGS)       -DXUA_ADAT_RX_EN=1
+
+# Audio Class 2, Async, I2S master, 8xInput, 16xOutput, ADAT Tx
+INCLUDE_ONLY_IN_2AMi8o16xxxxax =
+XCC_FLAGS_2AMi8o16xxxxax = $(BUILD_FLAGS)       -DXUA_ADAT_TX_EN=1
 
 # Audio Class 2, Async, I2S Slave, 10xInput, 10xOutput, S/PDIF Tx, S/PDIF Rx
 INCLUDE_ONLY_IN_2ASi10o10xssxxx =
@@ -48,3 +65,7 @@ XCC_FLAGS_2AMi16o8xxxaxx = $(BUILD_FLAGS)       -DXUA_ADAT_RX_EN=1
 INCLUDE_ONLY_IN_2AMi8o16xxxxax =
 XCC_FLAGS_2AMi8o16xxxxax = $(BUILD_FLAGS)       -DXUA_ADAT_TX_EN=1
 
+# Audio Class 1, Sync, I2S Master, 2xInput, 2xOutput
+INCLUDE_ONLY_IN_1SMi2o2xxxxxx =
+XCC_FLAGS_1SMi2o2xxxxxx = $(BUILD_FLAGS)        -DAUDIO_CLASS=1 \
+                                                -DXUA_SYNCMODE=XUA_SYNCMODE_SYNC

--- a/app_usb_aud_xk_316_mc/configs_partial.inc
+++ b/app_usb_aud_xk_316_mc/configs_partial.inc
@@ -12,10 +12,6 @@ INCLUDE_ONLY_IN_2AMi2o2xxxxxx =
 XCC_FLAGS_2AMi2o2xxxxxx = $(BUILD_FLAGS)        -DI2S_CHANS_DAC=2 \
                                                 -DI2S_CHANS_ADC=2
 
-# Audio Class 2, Async, I2S Master, 8xInput, 8xOutput
-INCLUDE_ONLY_IN_2AMi8o8xxxxxx =
-XCC_FLAGS_2AMi8o8xxxxxx = $(BUILD_FLAGS)
-
 # Audio Class 2, Async, I2S Slave, 8xInput, 8xOutput
 XCC_FLAGS_2ASi8o8xxxxxx = $(BUILD_FLAGS)		-DCODEC_MASTER=1
 INCLUDE_ONLY_IN_2ASi8o8xxxxxx =
@@ -32,14 +28,6 @@ XCC_FLAGS_2AMi32o32xxxxxx_tdm8 = $(BUILD_FLAGS)	-DXUA_PCM_FORMAT=XUA_PCM_FORMAT_
 # Audio Class 2, Async, I2S Master, 8xInput, 10xOutput, S/PDIF Tx
 INCLUDE_ONLY_IN_2AMi8o10xxsxxx =
 XCC_FLAGS_2AMi8o10xxsxxx = $(BUILD_FLAGS)		-DXUA_SPDIF_TX_EN=1
-
-# Audio Class 2, Async, I2S Master, 16xInput, 8xOutput, ADAT Rx
-INCLUDE_ONLY_IN_2AMi16o8xxxaxx =
-XCC_FLAGS_2AMi16o8xxxaxx = $(BUILD_FLAGS)       -DXUA_ADAT_RX_EN=1
-
-# Audio Class 2, Async, I2S master, 8xInput, 16xOutput, ADAT Tx
-INCLUDE_ONLY_IN_2AMi8o16xxxxax =
-XCC_FLAGS_2AMi8o16xxxxax = $(BUILD_FLAGS)       -DXUA_ADAT_TX_EN=1
 
 # Audio Class 2, Async, I2S Slave, 10xInput, 10xOutput, S/PDIF Tx, S/PDIF Rx
 INCLUDE_ONLY_IN_2ASi10o10xssxxx =

--- a/tests/test_adat.py
+++ b/tests/test_adat.py
@@ -19,6 +19,7 @@ from usb_audio_test_utils import (
 )
 from conftest import list_configs, get_config_features
 
+
 class AdatClockSrc:
     def __init__(self):
         self.cmd = [get_volcontrol_path()]
@@ -36,12 +37,24 @@ class AdatClockSrc:
         cmd = self.cmd + ["--clock", "Internal"]
         subprocess.run(cmd, timeout=10)
 
-def adat_common_uncollect(features, board, pytestconfig):
+
+adat_smoke_configs = [
+    ("xk_216_mc", "2AMi18o18mssaax"),
+    ("xk_316_mc", "2AMi16o16xxxaax"),
+]
+
+
+def adat_common_uncollect(features, board, config, pytestconfig):
     xtag_ids = get_xtag_dut_and_harness(pytestconfig, board)
     # XTAGs not present
     if not all(xtag_ids):
         return True
     if features["i2s_loopback"]:
+        return True
+    if (
+        pytestconfig.getoption("level") == "smoke"
+        and (board, config) not in adat_smoke_configs
+    ):
         return True
     return False
 
@@ -49,14 +62,14 @@ def adat_common_uncollect(features, board, pytestconfig):
 def adat_input_uncollect(pytestconfig, board, config):
     features = get_config_features(board, config)
     return any(
-        [not features["adat_i"], adat_common_uncollect(features, board, pytestconfig)]
+        [not features["adat_i"], adat_common_uncollect(features, board, config, pytestconfig)]
     )
 
 
 def adat_output_uncollect(pytestconfig, board, config):
     features = get_config_features(board, config)
     return any(
-        [not features["adat_o"], adat_common_uncollect(features, board, pytestconfig)]
+        [not features["adat_o"], adat_common_uncollect(features, board, config, pytestconfig)]
     )
 
 

--- a/tests/test_adat.py
+++ b/tests/test_adat.py
@@ -79,7 +79,7 @@ def adat_duration(level, partial):
     elif level == "nightly":
         duration = 15 if partial else 180
     else:
-        duration = 10
+        duration = 5
     return duration
 
 @pytest.mark.uncollect_if(func=adat_input_uncollect)

--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -81,7 +81,7 @@ def analogue_duration(level, partial):
     elif level == "nightly":
         duration = 15 if partial else 180
     else:
-        duration = 10
+        duration = 5
     return duration
 
 

--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -17,6 +17,13 @@ from usb_audio_test_utils import (
 from conftest import list_configs, get_config_features
 
 
+analogue_smoke_configs = [
+    ("xk_216_mc", "2AMi18o18mssaax"),
+    ("xk_216_mc", "2ASi10o10xssxxx"),
+    ("xk_evk_xu316", "1AMi2o2xxxxxx"),
+]
+
+
 def analogue_OS_uncollect(features, board, config):
     if (
         platform.system() == "Darwin"
@@ -38,7 +45,7 @@ def analogue_require_dut_and_harness(features, board, config, pytestconfig):
 
 def analogue_common_uncollect(features, board, config, pytestconfig):
     level = pytestconfig.getoption("level")
-    if level == "smoke" and board == "xk_316_mc":
+    if level == "smoke" and (board, config) not in analogue_smoke_configs:
         return True
     if analogue_OS_uncollect(features, board, config):
         return True

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -48,6 +48,10 @@ interface_configs = [
 
 
 def interface_uncollect(pytestconfig, board, config):
+    if pytestconfig.getoption("level") == "smoke":
+        # Don't run test_interfaces at smoke level
+        return True
+
     xtag_ids = get_xtag_dut_and_harness(pytestconfig, board)
     # XTAGs not present
     if not all(xtag_ids):

--- a/tests/test_loopback.py
+++ b/tests/test_loopback.py
@@ -14,6 +14,13 @@ from usb_audio_test_utils import (
 from conftest import list_configs, get_config_features
 
 
+loopback_smoke_configs = [
+    ("xk_316_mc", "2AMi18o18mssaax_i2sloopback"),
+    ("xk_316_mc", "2AMi8o8xxxxxx_mix8_i2sloopback"),
+    ("xk_316_mc", "2SSi8o8xxxxxx_i2sloopback"),
+]
+
+
 def OS_uncollect(features, board, config):
     if (
         platform.system() == "Darwin"
@@ -36,6 +43,8 @@ def loopback_dac_uncollect(pytestconfig, board, config):
         return True
     if not features["analogue_o"]:
         # No output channels
+        return True
+    if pytestconfig.getoption("level") == "smoke" and (board, config) not in loopback_smoke_configs:
         return True
     return False
 

--- a/tests/test_loopback.py
+++ b/tests/test_loopback.py
@@ -48,13 +48,13 @@ def loopback_dac_uncollect(pytestconfig, board, config):
         return True
     return False
 
-def analogue_duration(level, partial):
+def loopback_dac_duration(level, partial):
     if level == "weekend":
         duration = 90 if partial else 1200
     elif level == "nightly":
         duration = 15 if partial else 180
     else:
-        duration = 10
+        duration = 5
     return duration
 
 @pytest.mark.uncollect_if(func=loopback_dac_uncollect)
@@ -68,7 +68,7 @@ def test_loopback_dac(pytestconfig, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / f"{xsig_config}.json"
 
     adapter_dut = get_xtag_dut(pytestconfig, board)
-    duration = analogue_duration(pytestconfig.getoption("level"), features["partial"])
+    duration = loopback_dac_duration(pytestconfig.getoption("level"), features["partial"])
     fail_str = ""
 
     with XrunDut(adapter_dut, board, config) as dut:

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -63,7 +63,7 @@ def midi_duration(level, partial):
     elif level == "nightly":
         duration = 15 if partial else 180
     else:
-        duration = 10
+        duration = 5
     return duration
 
 def midi_receive_with_timeout(in_port, timeout_s=10, fail_on_timeout=True):

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -25,6 +25,10 @@ input_midi_file_name = 'tools/midifiles/Bach.mid'
 output_midi_file_name = 'tools/midifiles/Bach_loopback.mid'
 
 
+midi_loopback_smoke_configs = [
+    ("xk_316_mc", "2AMi18o18mssaax"),
+]
+
 def midi_loopback_uncollect(pytestconfig, board, config):
     features = get_config_features(board, config)
     xtag_ids = get_xtag_dut_and_harness(pytestconfig, board)
@@ -42,6 +46,12 @@ def midi_loopback_uncollect(pytestconfig, board, config):
         return True
 
     if not features["midi"]:
+        return True
+
+    if (
+        pytestconfig.getoption("level") == "smoke"
+        and (board, config) not in midi_loopback_smoke_configs
+    ):
         return True
 
     return False

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -33,10 +33,6 @@ def midi_loopback_uncollect(pytestconfig, board, config):
     features = get_config_features(board, config)
     xtag_ids = get_xtag_dut_and_harness(pytestconfig, board)
 
-    # Until we fix Jenkins user permissions for MIDI on Mac https://xmosjira.atlassian.net/browse/UA-254
-    if platform.system() == "Darwin":
-        return True
-
     # Skip loopback
     if features["i2s_loopback"]:
         return True

--- a/tests/test_midi_stress.py
+++ b/tests/test_midi_stress.py
@@ -32,6 +32,10 @@ def midi_stress_uncollect(pytestconfig, board, config):
     features = get_config_features(board, config)
     xtag_ids = get_xtag_dut_and_harness(pytestconfig, board)
 
+    if pytestconfig.getoption("level") == "smoke":
+        # Don't run MIDI stress at smoke level
+        return True
+
     # XTAGs not present
     if not all(xtag_ids):
         return True

--- a/tests/test_midi_stress.py
+++ b/tests/test_midi_stress.py
@@ -40,10 +40,6 @@ def midi_stress_uncollect(pytestconfig, board, config):
     if not all(xtag_ids):
         return True
 
-    # Until we fix Jenkins user permissions for MIDI on Mac https://xmosjira.atlassian.net/browse/UA-254
-    if platform.system() == "Darwin":
-        return True
-
     if features["i2s_loopback"]:
         return True
 

--- a/tests/test_midi_stress.py
+++ b/tests/test_midi_stress.py
@@ -53,13 +53,13 @@ def midi_stress_uncollect(pytestconfig, board, config):
     return False
 
 
-def midi_duration(level, partial):
+def midi_stress_duration(level, partial):
     if level == "weekend":
         duration = 90 if partial else 1200
     elif level == "nightly":
         duration = 15 if partial else 180
     else:
-        duration = 10
+        duration = 5
     return duration
 
 @pytest.mark.uncollect_if(func=midi_stress_uncollect)
@@ -79,7 +79,7 @@ def test_midi_loopback_stress(pytestconfig, board, config):
     xsig_config_path = Path(__file__).parent / "xsig_configs" / f"{xsig_config}.json"
 
     adapter_dut, adapter_harness = get_xtag_dut_and_harness(pytestconfig, board)
-    duration = midi_duration(pytestconfig.getoption("level"), features["partial"])
+    duration = midi_stress_duration(pytestconfig.getoption("level"), features["partial"])
     fail_str = ""
 
     fs_audio = max(features["samp_freqs"]) # Highest rate for maximum stress

--- a/tests/test_mixer_ctrl.py
+++ b/tests/test_mixer_ctrl.py
@@ -36,7 +36,7 @@ mixer_configs = [
 ]
 
 
-def mixer_uncollect(pytestconfig, board, config):
+def mixer_common_uncollect(pytestconfig, board, config):
     # Check if mixer configs are present for this test level
     if (board, config) not in list_configs():
         return True
@@ -47,7 +47,19 @@ def mixer_uncollect(pytestconfig, board, config):
     return False
 
 
-@pytest.mark.uncollect_if(func=mixer_uncollect)
+def mixing_ctrl_output_uncollect(pytestconfig, board, config):
+    return mixer_common_uncollect(pytestconfig, board, config)
+
+
+def mixer_not_smoke_uncollect(pytestconfig, board, config):
+    if pytestconfig.getoption("level") == "smoke":
+        # Don't run at smoke level
+        return True
+
+    return mixer_common_uncollect(pytestconfig, board, config)
+
+
+@pytest.mark.uncollect_if(func=mixer_not_smoke_uncollect)
 @pytest.mark.parametrize(["board", "config"], mixer_configs)
 def test_routing_ctrl_input(pytestconfig, ctrl_app, board, config):
     features = get_config_features(board, config)
@@ -90,7 +102,7 @@ def test_routing_ctrl_input(pytestconfig, ctrl_app, board, config):
         pytest.fail(fail_str)
 
 
-@pytest.mark.uncollect_if(func=mixer_uncollect)
+@pytest.mark.uncollect_if(func=mixer_not_smoke_uncollect)
 @pytest.mark.parametrize(["board", "config"], mixer_configs)
 def test_routing_ctrl_output(pytestconfig, ctrl_app, board, config):
     features = get_config_features(board, config)
@@ -139,7 +151,7 @@ def clear_default_mixes(ctrl_app, num_mixes):
         subprocess.run(mixer_cmd, timeout=10)
 
 
-@pytest.mark.uncollect_if(func=mixer_uncollect)
+@pytest.mark.uncollect_if(func=mixer_not_smoke_uncollect)
 @pytest.mark.parametrize(["board", "config"], mixer_configs)
 def test_mixing_ctrl_input(pytestconfig, ctrl_app, board, config):
     features = get_config_features(board, config)
@@ -206,7 +218,7 @@ def test_mixing_ctrl_input(pytestconfig, ctrl_app, board, config):
         pytest.fail(fail_str)
 
 
-@pytest.mark.uncollect_if(func=mixer_uncollect)
+@pytest.mark.uncollect_if(func=mixing_ctrl_output_uncollect)
 @pytest.mark.parametrize(["board", "config"], mixer_configs)
 def test_mixing_ctrl_output(pytestconfig, ctrl_app, board, config):
     features = get_config_features(board, config)
@@ -273,7 +285,7 @@ def test_mixing_ctrl_output(pytestconfig, ctrl_app, board, config):
         pytest.fail(fail_str)
 
 
-@pytest.mark.uncollect_if(func=mixer_uncollect)
+@pytest.mark.uncollect_if(func=mixer_not_smoke_uncollect)
 @pytest.mark.parametrize(["board", "config"], mixer_configs)
 def test_mixing_multi_channel_output(pytestconfig, ctrl_app, board, config):
     features = get_config_features(board, config)
@@ -357,7 +369,7 @@ def test_mixing_multi_channel_output(pytestconfig, ctrl_app, board, config):
         pytest.fail(fail_str)
 
 
-@pytest.mark.uncollect_if(func=mixer_uncollect)
+@pytest.mark.uncollect_if(func=mixer_not_smoke_uncollect)
 @pytest.mark.parametrize(["board", "config"], mixer_configs)
 def test_routing_daw_out_mix_input(pytestconfig, ctrl_app, board, config):
     features = get_config_features(board, config)

--- a/tests/test_spdif.py
+++ b/tests/test_spdif.py
@@ -85,7 +85,7 @@ def spdif_duration(level, partial):
     elif level == "nightly":
         duration = 15 if partial else 180
     else:
-        duration = 10
+        duration = 5
     return duration
 
 

--- a/tests/test_spdif.py
+++ b/tests/test_spdif.py
@@ -38,12 +38,23 @@ class SpdifClockSrc:
         subprocess.run(cmd, timeout=10)
 
 
-def spdif_common_uncollect(features, board, pytestconfig):
+spdif_smoke_configs = [
+    ("xk_216_mc", "2AMi18o18mssaax"),
+    ("xk_316_mc", "2AMi10o10xssxxx"),
+]
+
+
+def spdif_common_uncollect(features, board, config, pytestconfig):
     xtag_ids = get_xtag_dut_and_harness(pytestconfig, board)
     # XTAGs not present
     if not all(xtag_ids):
         return True
     if features["i2s_loopback"]:
+        return True
+    if (
+        pytestconfig.getoption("level") == "smoke"
+        and (board, config) not in spdif_smoke_configs
+    ):
         return True
     return False
 
@@ -51,14 +62,20 @@ def spdif_common_uncollect(features, board, pytestconfig):
 def spdif_input_uncollect(pytestconfig, board, config):
     features = get_config_features(board, config)
     return any(
-        [not features["spdif_i"], spdif_common_uncollect(features, board, pytestconfig)]
+        [
+            not features["spdif_i"],
+            spdif_common_uncollect(features, board, config, pytestconfig),
+        ]
     )
 
 
 def spdif_output_uncollect(pytestconfig, board, config):
     features = get_config_features(board, config)
     return any(
-        [not features["spdif_o"], spdif_common_uncollect(features, board, pytestconfig)]
+        [
+            not features["spdif_o"],
+            spdif_common_uncollect(features, board, config, pytestconfig),
+        ]
     )
 
 
@@ -95,8 +112,12 @@ def test_spdif_input(pytestconfig, board, config):
             num_dig_in_channels = num_in_channels - features["analogue_i"]
             xsig_config = f'mc_digital_input_analog_{features["analogue_i"]}ch_dig_{num_dig_in_channels}ch'
             if features["adat_i"]:
-                xsig_config = xsig_config + "_spdif" # If adat is also enabled use a config that only tests spdif
-            xsig_config_path = Path(__file__).parent / "xsig_configs" / f"{xsig_config}.json"
+                xsig_config = (
+                    xsig_config + "_spdif"
+                )  # If adat is also enabled use a config that only tests spdif
+            xsig_config_path = (
+                Path(__file__).parent / "xsig_configs" / f"{xsig_config}.json"
+            )
 
             dut.set_stream_format("input", fs, num_in_channels, 24)
 
@@ -179,10 +200,14 @@ def test_spdif_output(pytestconfig, board, config):
             num_dig_out_channels = num_out_channels - features["analogue_o"]
             xsig_config = f'mc_digital_output_analog_{features["analogue_o"]}ch_dig_{num_dig_out_channels}ch'
             if features["adat_o"]:
-                xsig_config = xsig_config + "_spdif" # When adat is also enabled check only spdif channels
-            xsig_config_path = Path(__file__).parent / "xsig_configs" / f"{xsig_config}.json"
+                xsig_config = (
+                    xsig_config + "_spdif"
+                )  # When adat is also enabled check only spdif channels
+            xsig_config_path = (
+                Path(__file__).parent / "xsig_configs" / f"{xsig_config}.json"
+            )
 
-            if(features["chan_i"] > num_out_channels):
+            if features["chan_i"] > num_out_channels:
                 dut.set_stream_format("input", fs, num_out_channels, 24)
 
             dut.set_stream_format("output", fs, num_out_channels, 24)


### PR DESCRIPTION
- disabled Windows agents in the smoke level job
- added hard-coded list of configs to run at the smoke level: these should be a choice of the minimal number of configs to get quick coverage of the features being tested; the nightly and weekend jobs still run every config
- enabled MIDI testing on MacOS agents
