### PR TITLE
Remove any device nodes from previously disconnnected xmos devices be…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import shutil
 import yaml
 
 from hardware_test_tools.UaDut import UaDut
+from hardware_test_tools.pnputil_remove_device import remove_xmos_device_nodes
 
 
 def pytest_addoption(parser):
@@ -129,6 +130,10 @@ def parse_features(board, config):
     return features
 
 def pytest_sessionstart(session):
+    if platform.system() == "Windows":
+        print("Deleting any existing device nodes before running tests...")
+        remove_xmos_device_nodes(0x20b1) # remove any existing nodes of previously disconnected devices before running tests
+
     usb_audio_dir = Path(__file__).parents[1]
     app_prefix = "app_usb_aud_"
     exclude_app = ["app_usb_aud_xk_evk_xu316_extrai2s"]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,4 +6,5 @@ python-rtmidi==1.5.8
 mido==1.3.2
 pyyaml==6.0.2
 
--e ./../../hardware_test_tools
+-e git+ssh://git@github.com/xmos/hardware_test_tools.git@71d06ee6d113d2954b3279345f71ba5aaf204be8#egg=hardware_test_tools
+-e git+ssh://git@github0.xmos.com/xmos-int/xtagctl.git@v2.0.0#egg=xtagctl


### PR DESCRIPTION
…fore running the tests

Also, after every test, after disconnecting the device, remove any non-present child device nodes using pnputil /remove-device. This is a change to hardware_test_tools merged as part of https://github.com/xmos/hardware_test_tools/pull/22

This fixes the issue of the Thesycon driver reinstall taking upwards of an hour. According to Frank from Thesycon,

_"The problem is that usbdeview.exe doesn't delete the complete child device node tree. So non-present child device nodes are left on the system. If you than reconnect the device new child device nodes created. If you call this often during your tests you end up with a large number of non present device nodes. Our uninstall than also deletes all this non-present device nodes. That takes a long time.
You can also delete the device nodes with Windows inbox tool pnputil: https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/pnputil-command-syntax
The command "PNPUTIL /remove-device <instance ID> /subtree" should work correctly and delete all child nodes. But you need to get the instance ID e.g. with "PNPUTIL /enum-devices"_

https://github.com/xmos/hardware_test_tools/pull/22 has changes for removing any non-present device nodes after every test run using pnputil instead of usbdeview.

I tested this by running 2 nightlies with this change and then manually uninstalling the driver on both the windows agents and confirming that the uninstall happens very fast (less than a minute)

I'm hoping that this fix will also solve the problem of timeouts during device enumeration which we would see on the Windows agents after running nightlies for a few days, which the driver reinstall would fix (leading us to notice the long unistall time in the first place), but that needs more monitoring of the nightly failures over a week or so after this is merged.

