### PR TITLE
Optional: changed app_usb_aud_xk_316_mc app to enumerate as speakers …

### DIFF
--- a/app_usb_aud_xk_316_mc/CMakeLists.txt
+++ b/app_usb_aud_xk_316_mc/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SW_USB_AUDIO_FLAGS ${EXTRA_BUILD_FLAGS} -O3
                                             -g
                                             -fxscope
                                             -DBOARD_SUPPORT_BOARD=XK_AUDIO_316_MC_AB
-                                            -DXUA_DESC_INPUT_TYPE_LINE_IN
+                                            -DXUA_DESC_INPUT_TYPE_LINE_IN=1
                                             -DADAT_TX_USE_SHARED_BUFF=1)
 
 ## HiBW configs


### PR DESCRIPTION
…+ line in instead of speakers + mics

Exercises the code in (and, thus depends on) https://github.com/xmos/lib_xua/pull/521