### PR TITLE
Updates to reflect changes in lib_xua for DFU

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -97,8 +97,8 @@ UNRELEASED
 
     - lib_xud: 3.0.1 -> 4.0.0
 
-      + ADDED: Support for high bandwidth ISO endpoints
-      + REMOVED: Support for legacy API XUD_Manager()
+      + ADDED:    Support for high bandwidth ISO endpoints
+      + REMOVED:  Support for legacy API XUD_Manager()
 
 9.1.0
 -----

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // This file relates to internal XMOS infrastructure and should be ignored by external users
 
-@Library('xmos_jenkins_shared_library@v0.49.0') _
+@Library('xmos_jenkins_shared_library@v0.51.1') _
 
 // Get XCommon CMake.
 // This is required for compiling a factory image for a DFU test using tools 15.2.1
@@ -39,7 +39,7 @@ pipeline {
     )
     string(
       name: 'XMOSDOC_VERSION',
-      defaultValue: 'v8.0.1',
+      defaultValue: 'v8.0.3',
       description: 'The xmosdoc version')
 
     string(
@@ -233,9 +233,9 @@ pipeline {
 
                       withXTAG(["usb_audio_mc_xs2_dut", "usb_audio_mc_xs2_harness", \
                                 "usb_audio_xcai_exp_dut", "usb_audio_xcai_exp_harness"]) { xtagIds ->
-                        sh "pytest -v --level nightly --junitxml=pytest_result_mac_intel.xml \
+                        sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_intel.xml \
                             -o xk_216_mc_dut=${xtagIds[0]} -o xk_216_mc_harness=${xtagIds[1]} \
-                            -o xk_evk_xu316_dut=${xtagIds[2]} -o xk_evk_xu316_harness=${xtagIds[3]} --midi-send-delay 0.001 -k dfu"
+                            -o xk_evk_xu316_dut=${xtagIds[2]} -o xk_evk_xu316_harness=${xtagIds[3]} --midi-send-delay 0.001"
                       }
                       archiveArtifacts artifacts: "${env.VIRTUAL_ENV}/src/hardware-test-tools/xsig/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
                     }
@@ -296,9 +296,9 @@ pipeline {
                       } // dir("${env.VIRTUAL_ENV}/src/hardware-test-tools")
 
                       withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
-                        sh "pytest -v --level nightly --junitxml=pytest_result_mac_arm.xml \
+                        sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_arm.xml \
                             -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]} \
-                            -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]} -k dfu"
+                            -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]}"
                       }
                       archiveArtifacts artifacts: "${env.VIRTUAL_ENV}/src/hardware-test-tools/xsig/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
                     }
@@ -356,9 +356,9 @@ pipeline {
                       }
                     } // dir("${env.VIRTUAL_ENV}/src/hardware-test-tools")
                     withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
-                      sh "pytest -v --level nightly --junitxml=pytest_result_windows10.xml \
+                      sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_windows10.xml \
                           -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]} \
-                          -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]} -k dfu"
+                          -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]}"
                     }
                     archiveArtifacts artifacts: "${env.VIRTUAL_ENV}/src/hardware-test-tools/xsig/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
                   }
@@ -415,9 +415,9 @@ pipeline {
                       }
                     } // dir("${env.VIRTUAL_ENV}/src/hardware-test-tools")
                     withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
-                      sh "pytest -v --level nightly --junitxml=pytest_result_windows11.xml \
+                      sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_windows11.xml \
                           -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]} \
-                          -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]} -k dfu"
+                          -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]}"
                     }
                     archiveArtifacts artifacts: "${env.VIRTUAL_ENV}/src/hardware-test-tools/xsig/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // This file relates to internal XMOS infrastructure and should be ignored by external users
 
-@Library('xmos_jenkins_shared_library@v0.43.3') _
+@Library('xmos_jenkins_shared_library@v0.49.0') _
 
 // Get XCommon CMake.
 // This is required for compiling a factory image for a DFU test using tools 15.2.1
@@ -39,12 +39,12 @@ pipeline {
     )
     string(
       name: 'XMOSDOC_VERSION',
-      defaultValue: 'v8.0.0',
+      defaultValue: 'v8.0.1',
       description: 'The xmosdoc version')
 
     string(
       name: 'INFR_APPS_VERSION',
-      defaultValue: 'v3.2.1',
+      defaultValue: 'v3.4.0',
       description: 'The infr_apps version'
     )
     choice(name: 'TEST_LEVEL', choices: ['smoke', 'nightly', 'weekend'],
@@ -62,6 +62,9 @@ pipeline {
   }
   stages {
     stage('Setup') {
+      agent {
+        label 'linux && x86_64'
+      }
       steps {
         script {
           def (server, user, repo) = extractFromScmUrl()
@@ -71,7 +74,7 @@ pipeline {
     }
     stage('Build') {
       parallel {
-        stage('🏗️ xcommon cmake Build + lib checks') {
+        stage('🏗️ Build') {
           agent {
             label 'linux && x86_64'
           }
@@ -98,7 +101,7 @@ pipeline {
                   }
 
                   dir("app_usb_aud_xk_316_mc") {
-                    xcoreBuild(buildDir: "build_loopback", archive_bins: false, cmakeOpts: "-DPARTIAL_TESTED_CONFIGS=1 -DEXTRA_BUILD_FLAGS='-DI2S_LOOPBACK=1' -DENABLE_I2S_TIMING_CHECK=ON")
+                    xcoreBuild(buildDir: "build_loopback", archiveBins: false, cmakeOpts: "-DPARTIAL_TESTED_CONFIGS=1 -DEXTRA_BUILD_FLAGS='-DI2S_LOOPBACK=1' -DENABLE_I2S_TIMING_CHECK=ON")
                     sh 'for folder in bin/?*; do if [[ ! $folder == *"old_tools"* ]] ; then mv "$folder" "${folder/%/_i2sloopback}"; fi ; done'
                     sh 'for config in bin/?*/*.xe; do if [[ ! $config == *"old_tools"* ]] ; then mv "$config" "${config/%.xe/_i2sloopback.xe}"; fi ; done'
                   }
@@ -112,6 +115,35 @@ pipeline {
               }
             } // stage('Apps build')
 
+            stage("Archive sandbox") {
+              steps {
+                archiveSandbox(REPO_NAME)
+              }
+            } // stage("Archive sandbox")
+          } // stages
+          post {
+            cleanup {
+              xcoreCleanSandbox()
+            }
+          }
+        } // stage('🏗️ Build')
+
+        stage('Docs and lib checks') {
+          // Use XCommon CMake to fetch dependencies, but then build using legacy XCommon Makefiles
+          agent {
+            label 'linux && x86_64'
+          }
+          stages {
+            stage('Checkout') {
+              steps {
+                println "Stage running on ${env.NODE_NAME}"
+
+                dir(REPO_NAME){
+                  checkoutScmShallow()
+                }
+              }
+            } // stage('Checkout')
+            
             stage('Repo checks') {
               steps {
                 warnError("Repo checks failed")
@@ -125,6 +157,10 @@ pipeline {
               steps {
                 dir(REPO_NAME) {
                   createVenv()
+                  withTools(params.TOOLS_VERSION) {
+                    // Fetch all dependencies using XCommon CMake
+                    sh "cmake -G 'Unix Makefiles' -B build -DDEPS_CLONE_SHALLOW=TRUE"
+                  }
                   buildDocs(xmosdocVenvPath: ".")
                 } // dir(REPO_NAME)
               } // steps
@@ -144,46 +180,13 @@ pipeline {
               }
             }
 
-            stage("Archive sandbox") {
-              steps {
-                archiveSandbox(REPO_NAME)
-              }
-            } // stage("Archive sandbox")
           } // stages
           post {
             cleanup {
               xcoreCleanSandbox()
             }
-          }
-        } // stage('🏗️ xcommon cmake Build and lib checks')
-
-        stage('legacy xmake build') {
-          // Use XCommon CMake to fetch dependencies, but then build using legacy XCommon Makefiles
-          agent {
-            label 'linux && x86_64'
-          }
-          steps {
-            println "Stage running on ${env.NODE_NAME}"
-
-            dir(REPO_NAME) {
-              checkoutScmShallow()
-
-              withTools(params.TOOLS_VERSION) {
-                // Fetch all dependencies using XCommon CMake
-                sh "cmake -G 'Unix Makefiles' -B build -DDEPS_CLONE_SHALLOW=TRUE"
-                sh 'xmake -C app_usb_aud_xk_316_mc -j16'
-                sh 'xmake -C app_usb_aud_xk_216_mc -j16'
-                sh 'xmake -C app_usb_aud_xk_evk_xu316 -j16'
-                sh 'xmake -C app_usb_aud_xk_evk_xu316_extrai2s -j16'
-              }
-            }
-          } // steps
-          post {
-            cleanup {
-              xcoreCleanSandbox()
-            }
           } // post
-        } // stage('legacy xmake build')
+        } // stage('Docs and lib checks')
       } // parallel
     }  // stage('Build')
 
@@ -224,15 +227,15 @@ pipeline {
                           copyArtifacts filter: 'bin-macos-x86/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
                         }
                         dir("xmosdfu") {
-                          copyArtifacts filter: 'host/macos-x86_64/xmosdfu', fingerprintArtifacts: true, projectName: 'XMOS/lib_dfu/develop', flatten: true, selector: lastSuccessful()
+                          copyArtifacts filter: 'host/macos-x86_64/xmosdfu', fingerprintArtifacts: true, projectName: 'XMOS/lib_dfu/PR-100', flatten: true, selector: lastSuccessful()
                         }
                       } // dir("${env.VIRTUAL_ENV}/src/hardware-test-tools")
 
                       withXTAG(["usb_audio_mc_xs2_dut", "usb_audio_mc_xs2_harness", \
                                 "usb_audio_xcai_exp_dut", "usb_audio_xcai_exp_harness"]) { xtagIds ->
-                        sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_intel.xml \
+                        sh "pytest -v --level nightly --junitxml=pytest_result_mac_intel.xml \
                             -o xk_216_mc_dut=${xtagIds[0]} -o xk_216_mc_harness=${xtagIds[1]} \
-                            -o xk_evk_xu316_dut=${xtagIds[2]} -o xk_evk_xu316_harness=${xtagIds[3]} --midi-send-delay 0.001"
+                            -o xk_evk_xu316_dut=${xtagIds[2]} -o xk_evk_xu316_harness=${xtagIds[3]} --midi-send-delay 0.001 -k dfu"
                       }
                       archiveArtifacts artifacts: "${env.VIRTUAL_ENV}/src/hardware-test-tools/xsig/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
                     }
@@ -288,14 +291,14 @@ pipeline {
                           copyArtifacts filter: 'bin-macos-arm/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
                         }
                         dir("xmosdfu") {
-                          copyArtifacts filter: 'host/macos-arm64/xmosdfu', fingerprintArtifacts: true, projectName: 'XMOS/lib_dfu/develop', flatten: true, selector: lastSuccessful()
+                          copyArtifacts filter: 'host/macos-arm64/xmosdfu', fingerprintArtifacts: true, projectName: 'XMOS/lib_dfu/PR-100', flatten: true, selector: lastSuccessful()
                         }
                       } // dir("${env.VIRTUAL_ENV}/src/hardware-test-tools")
 
                       withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
-                        sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_mac_arm.xml \
+                        sh "pytest -v --level nightly --junitxml=pytest_result_mac_arm.xml \
                             -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]} \
-                            -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]}"
+                            -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]} -k dfu"
                       }
                       archiveArtifacts artifacts: "${env.VIRTUAL_ENV}/src/hardware-test-tools/xsig/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
                     }
@@ -353,9 +356,9 @@ pipeline {
                       }
                     } // dir("${env.VIRTUAL_ENV}/src/hardware-test-tools")
                     withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
-                      sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_windows10.xml \
+                      sh "pytest -v --level nightly --junitxml=pytest_result_windows10.xml \
                           -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]} \
-                          -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]}"
+                          -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]} -k dfu"
                     }
                     archiveArtifacts artifacts: "${env.VIRTUAL_ENV}/src/hardware-test-tools/xsig/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
                   }
@@ -412,9 +415,9 @@ pipeline {
                       }
                     } // dir("${env.VIRTUAL_ENV}/src/hardware-test-tools")
                     withXTAG(["usb_audio_mc_xcai_dut", "usb_audio_mc_xcai_harness"]) { xtagIds ->
-                      sh "pytest -v --level ${params.TEST_LEVEL} --junitxml=pytest_result_windows11.xml \
+                      sh "pytest -v --level nightly --junitxml=pytest_result_windows11.xml \
                           -o xk_316_mc_dut=${xtagIds[0]} -o xk_316_mc_harness=${xtagIds[1]} \
-                          -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]}"
+                          -o template_dut=${xtagIds[0]} -o template_harness=${xtagIds[1]} -k dfu"
                     }
                     archiveArtifacts artifacts: "${env.VIRTUAL_ENV}/src/hardware-test-tools/xsig/glitch.*.csv", fingerprint: true, allowEmptyArchive: true
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,7 +224,7 @@ pipeline {
                           copyArtifacts filter: 'bin-macos-x86/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
                         }
                         dir("xmosdfu") {
-                          copyArtifacts filter: 'OSX/x86/xmosdfu', fingerprintArtifacts: true, projectName: 'XMOS/lib_xua/develop', flatten: true, selector: lastSuccessful()
+                          copyArtifacts filter: 'host/macos-x86_64/xmosdfu', fingerprintArtifacts: true, projectName: 'XMOS/lib_dfu/develop', flatten: true, selector: lastSuccessful()
                         }
                       } // dir("${env.VIRTUAL_ENV}/src/hardware-test-tools")
 
@@ -288,7 +288,7 @@ pipeline {
                           copyArtifacts filter: 'bin-macos-arm/xsig', fingerprintArtifacts: true, projectName: 'xmos-int/xsig/master', flatten: true, selector: lastSuccessful()
                         }
                         dir("xmosdfu") {
-                          copyArtifacts filter: 'OSX/arm64/xmosdfu', fingerprintArtifacts: true, projectName: 'XMOS/lib_xua/develop', flatten: true, selector: lastSuccessful()
+                          copyArtifacts filter: 'host/macos-arm64/xmosdfu', fingerprintArtifacts: true, projectName: 'XMOS/lib_dfu/develop', flatten: true, selector: lastSuccessful()
                         }
                       } // dir("${env.VIRTUAL_ENV}/src/hardware-test-tools")
 

--- a/app_usb_aud_template/src/core/xua_conf.h
+++ b/app_usb_aud_template/src/core/xua_conf.h
@@ -1,4 +1,4 @@
-// Copyright 2012-2025 XMOS LIMITED.
+// Copyright 2012-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 // Defines relating to device configuration and customisation.

--- a/app_usb_aud_template/src/extensions/audiohw.xc
+++ b/app_usb_aud_template/src/extensions/audiohw.xc
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 XMOS LIMITED.
+// Copyright 2022-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "xua.h"
 

--- a/app_usb_aud_template/src/extensions/audiostream.xc
+++ b/app_usb_aud_template/src/extensions/audiostream.xc
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 XMOS LIMITED.
+// Copyright 2022-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 /* Called when audio streaming starts or stops

--- a/app_usb_aud_template/src/extensions/hostactive.xc
+++ b/app_usb_aud_template/src/extensions/hostactive.xc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 XMOS LIMITED.
+// Copyright 2023-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 /* Called when USB host becomes active or inactive

--- a/app_usb_aud_xk_216_mc/src/core/app_usb_aud_xk_216_mc.h
+++ b/app_usb_aud_xk_216_mc/src/core/app_usb_aud_xk_216_mc.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 XMOS LIMITED.
+// Copyright 2018-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef APP_USB_AUD_XK_216_MC_H_

--- a/app_usb_aud_xk_216_mc/src/core/user_main.h
+++ b/app_usb_aud_xk_216_mc/src/core/user_main.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 XMOS LIMITED.
+// Copyright 2022-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef USER_MAIN_H
 #define USER_MAIN_H

--- a/app_usb_aud_xk_216_mc/src/core/xua_conf.h
+++ b/app_usb_aud_xk_216_mc/src/core/xua_conf.h
@@ -1,4 +1,4 @@
-// Copyright 2012-2025 XMOS LIMITED.
+// Copyright 2012-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 /**
  * @file       xua_conf.h

--- a/app_usb_aud_xk_216_mc/src/extensions/audiohw.xc
+++ b/app_usb_aud_xk_216_mc/src/extensions/audiohw.xc
@@ -1,4 +1,4 @@
-// Copyright 2012-2025 XMOS LIMITED.
+// Copyright 2012-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "xua.h"
 

--- a/app_usb_aud_xk_216_mc/src/extensions/gpio_access.c
+++ b/app_usb_aud_xk_216_mc/src/extensions/gpio_access.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 XMOS LIMITED.
+// Copyright 2015-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "gpio_access.h"
 #include "swlock.h"

--- a/app_usb_aud_xk_216_mc/src/extensions/gpio_access.h
+++ b/app_usb_aud_xk_216_mc/src/extensions/gpio_access.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2025 XMOS LIMITED.
+// Copyright 2014-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef _GPIO_ACCESS_H_
 #define _GPIO_ACCESS_H_

--- a/app_usb_aud_xk_216_mc/src/extensions/hidbuttons.xc
+++ b/app_usb_aud_xk_216_mc/src/extensions/hidbuttons.xc
@@ -1,4 +1,4 @@
-// Copyright 2013-2025 XMOS LIMITED.
+// Copyright 2013-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <xs1.h>

--- a/app_usb_aud_xk_216_mc/src/extensions/interrupt.c
+++ b/app_usb_aud_xk_216_mc/src/extensions/interrupt.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 XMOS LIMITED.
+// Copyright 2015-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "app_usb_aud_xk_216_mc.h"
 

--- a/app_usb_aud_xk_216_mc/src/extensions/xuduser.xc
+++ b/app_usb_aud_xk_216_mc/src/extensions/xuduser.xc
@@ -1,4 +1,4 @@
-// Copyright 2014-2025 XMOS LIMITED.
+// Copyright 2014-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <platform.h>
 #include <xs1_su.h>

--- a/app_usb_aud_xk_216_mc/src/hid_report_descriptor.h
+++ b/app_usb_aud_xk_216_mc/src/hid_report_descriptor.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 XMOS LIMITED.
+// Copyright 2022-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef _hid_report_descriptor_h_
 #define _hid_report_descriptor_h_

--- a/app_usb_aud_xk_316_mc/src/core/xua_conf.h
+++ b/app_usb_aud_xk_316_mc/src/core/xua_conf.h
@@ -1,4 +1,4 @@
-// Copyright 2012-2025 XMOS LIMITED.
+// Copyright 2012-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 /**
  * @file       xua_conf.h

--- a/app_usb_aud_xk_316_mc/src/core/xua_conf_globals.h
+++ b/app_usb_aud_xk_316_mc/src/core/xua_conf_globals.h
@@ -1,4 +1,4 @@
-// Copyright 2025 XMOS LIMITED.
+// Copyright 2025-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <xk_audio_316_mc_ab/board.h>

--- a/app_usb_aud_xk_316_mc/src/core/xua_conf_tasks.h
+++ b/app_usb_aud_xk_316_mc/src/core/xua_conf_tasks.h
@@ -1,4 +1,4 @@
-// Copyright 2025 XMOS LIMITED.
+// Copyright 2025-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #if HID_CONTROLS > 0

--- a/app_usb_aud_xk_316_mc/src/extensions/XUD_HAL.xc
+++ b/app_usb_aud_xk_316_mc/src/extensions/XUD_HAL.xc
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 XMOS LIMITED.
+// Copyright 2022-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <print.h>
 #include "xua.h"

--- a/app_usb_aud_xk_316_mc/src/extensions/audiohw.xc
+++ b/app_usb_aud_xk_316_mc/src/extensions/audiohw.xc
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 XMOS LIMITED.
+// Copyright 2022-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "xua.h"
 #include <xk_audio_316_mc_ab/board.h>

--- a/app_usb_aud_xk_316_mc/src/extensions/audiostream.xc
+++ b/app_usb_aud_xk_316_mc/src/extensions/audiostream.xc
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 XMOS LIMITED.
+// Copyright 2022-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <platform.h>
 

--- a/app_usb_aud_xk_316_mc/src/extensions/hidbuttons.xc
+++ b/app_usb_aud_xk_316_mc/src/extensions/hidbuttons.xc
@@ -1,4 +1,4 @@
-// Copyright 2013-2025 XMOS LIMITED.
+// Copyright 2013-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <xs1.h>

--- a/app_usb_aud_xk_316_mc/src/extensions/hostactive.xc
+++ b/app_usb_aud_xk_316_mc/src/extensions/hostactive.xc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 XMOS LIMITED.
+// Copyright 2023-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <platform.h>
 

--- a/app_usb_aud_xk_316_mc/src/extensions/user_buffer_management.xc
+++ b/app_usb_aud_xk_316_mc/src/extensions/user_buffer_management.xc
@@ -1,4 +1,4 @@
-// Copyright 2017-2025 XMOS LIMITED.
+// Copyright 2017-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <xs1.h>

--- a/app_usb_aud_xk_316_mc/src/hid_report_descriptor.h
+++ b/app_usb_aud_xk_316_mc/src/hid_report_descriptor.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 XMOS LIMITED.
+// Copyright 2022-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef _hid_report_descriptor_h_
 #define _hid_report_descriptor_h_

--- a/app_usb_aud_xk_evk_xu316/src/core/xua_conf.h
+++ b/app_usb_aud_xk_evk_xu316/src/core/xua_conf.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 XMOS LIMITED.
+// Copyright 2021-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 /**
  * @file       xua_conf.h

--- a/app_usb_aud_xk_evk_xu316/src/core/xua_conf_declarations.h
+++ b/app_usb_aud_xk_evk_xu316/src/core/xua_conf_declarations.h
@@ -1,4 +1,4 @@
-// Copyright 2025 XMOS LIMITED.
+// Copyright 2025-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 chan c_audiohw;

--- a/app_usb_aud_xk_evk_xu316/src/core/xua_conf_globals.h
+++ b/app_usb_aud_xk_evk_xu316/src/core/xua_conf_globals.h
@@ -1,4 +1,4 @@
-// Copyright 2025 XMOS LIMITED.
+// Copyright 2025-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 void AudioHwRemote(chanend c);

--- a/app_usb_aud_xk_evk_xu316/src/core/xua_conf_tasks.h
+++ b/app_usb_aud_xk_evk_xu316/src/core/xua_conf_tasks.h
@@ -1,4 +1,4 @@
-// Copyright 2025 XMOS LIMITED.
+// Copyright 2025-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 on tile[1]: {

--- a/app_usb_aud_xk_evk_xu316/src/extensions/audiohw.xc
+++ b/app_usb_aud_xk_evk_xu316/src/extensions/audiohw.xc
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 XMOS LIMITED.
+// Copyright 2021-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "xua.h"
 #include "xk_evk_xu316/board.h"

--- a/app_usb_aud_xk_evk_xu316_extrai2s/src/core/user_main.h
+++ b/app_usb_aud_xk_evk_xu316_extrai2s/src/core/user_main.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 XMOS LIMITED.
+// Copyright 2021-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef _USER_MAIN_H_

--- a/app_usb_aud_xk_evk_xu316_extrai2s/src/core/xua_conf.h
+++ b/app_usb_aud_xk_evk_xu316_extrai2s/src/core/xua_conf.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 XMOS LIMITED.
+// Copyright 2021-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "../../../app_usb_aud_xk_evk_xu316/src/core/xua_conf.h"
 #include "./user_main.h"

--- a/app_usb_aud_xk_evk_xu316_extrai2s/src/extensions/audiohw.xc
+++ b/app_usb_aud_xk_evk_xu316_extrai2s/src/extensions/audiohw.xc
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 XMOS LIMITED.
+// Copyright 2021-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "../../../app_usb_aud_xk_evk_xu316/src/extensions/audiohw.xc"
 

--- a/app_usb_aud_xk_evk_xu316_extrai2s/src/extensions/extra_i2s.xc
+++ b/app_usb_aud_xk_evk_xu316_extrai2s/src/extensions/extra_i2s.xc
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 XMOS LIMITED.
+// Copyright 2021-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <platform.h>
 #include <xs1.h>

--- a/app_usb_aud_xk_evk_xu316_extrai2s/src/extensions/i2c_conf.h
+++ b/app_usb_aud_xk_evk_xu316_extrai2s/src/extensions/i2c_conf.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2025 XMOS LIMITED.
+// Copyright 2013-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef _I2C_CONF_H_
 #define _I2C_CONF_H_

--- a/app_usb_aud_xk_evk_xu316_extrai2s/src/hid_report_descriptor.h
+++ b/app_usb_aud_xk_evk_xu316_extrai2s/src/hid_report_descriptor.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 XMOS LIMITED.
+// Copyright 2021-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef __hid_report_descriptor_h__
 #define __hid_report_descriptor_h__

--- a/deps.cmake
+++ b/deps.cmake
@@ -1,4 +1,4 @@
-set(APP_DEPENDENT_MODULES "lib_xua(develop)"
+set(APP_DEPENDENT_MODULES "humphrey-xmos/lib_xua(feature/dfu-transition)"
                           "lib_i2c(6.4.1)"
                           "lib_i2s(6.0.1)"
-                          "lib_board_support(develop)")
+                          "lib_board_support(1.5.0)")

--- a/deps.cmake
+++ b/deps.cmake
@@ -1,4 +1,4 @@
-set(APP_DEPENDENT_MODULES "humphrey-xmos/lib_xua(feature/dfu-transition)"
+set(APP_DEPENDENT_MODULES "lib_xua(develop)"
                           "lib_i2c(6.4.1)"
                           "lib_i2s(6.0.1)"
                           "lib_board_support(1.5.0)")

--- a/shared/version.h
+++ b/shared/version.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 XMOS LIMITED.
+// Copyright 2022-2026 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // Shared version number for all reference designs
 #ifndef BCD_DEVICE_J

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 XMOS LIMITED.
+# Copyright 2020-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import pytest
 from pathlib import Path

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,5 +7,5 @@ mido==1.3.2
 pyyaml==6.0.2
 pytest-order==1.3.0
 
--e git+ssh://git@github.com/xmos/hardware_test_tools.git@604a1f90a01b5f17ac27205ef1243f41dbb762e7#egg=hardware_test_tools
+-e git+ssh://git@github.com/xmos/hardware_test_tools.git@adddab1c3186496e6683e82c9fe1f509111392bf#egg=hardware_test_tools
 -e git+ssh://git@github0.xmos.com/xmos-int/xtagctl.git@v2.0.0#egg=xtagctl

--- a/tests/test_adat.py
+++ b/tests/test_adat.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 XMOS LIMITED.
+# Copyright 2022-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from pathlib import Path
 import pytest

--- a/tests/test_analogue.py
+++ b/tests/test_analogue.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 XMOS LIMITED.
+# Copyright 2015-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from pathlib import Path
 import pytest

--- a/tests/test_dfu.py
+++ b/tests/test_dfu.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 XMOS LIMITED.
+# Copyright 2015-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from pathlib import Path
 import pytest

--- a/tests/test_dfu.py
+++ b/tests/test_dfu.py
@@ -58,6 +58,13 @@ def xtc_version():
     return match.groupdict()
 
 
+def check_upload_file(upload_file):
+    print("check upload file")
+    cmd = f"xflash --analyze {upload_file}".split()
+    ret = subprocess.run(cmd, text=True, capture_output=True, timeout=10)
+    assert ret.returncode == 0, f"Failed to analyze upload file, is file corrupted, cmd {cmd}\nstdout:\n{ret.stdout}\nstderr:\n{ret.stderr}"
+
+
 # Test cases are defined by a tuple of (board, initial config to xflash)
 dfu_testcases = [
     ("xk_216_mc", "2AMi10o10xssxxx"),
@@ -111,13 +118,24 @@ Sequence when testing other apps (eg. xk_316_mc, 2AMi10o10xssxxx):
 def test_dfu(pytestconfig, board, config, dfuapp):
     adapter_dut = get_xtag_dut(pytestconfig, board)
     writeall = False
-    if "old_tools" in config: # For the old_tools test the factory executable has been compiled and coverted to a binary file with an older XTC tools version
+    if "old_tools" in config: # For the old_tools test the factory executable has been compiled and converted to a binary file with an older XTC tools version
         writeall = True # In the test we only do xflash --write-all to write the binary file to the device and any xflash version would do at this point
+
+    if "dfu-util" in dfuapp:
+        ret = subprocess.run("dfu-util -V".split(), capture_output=True, text=True)
+        print(f"dfu-util check: {ret.stdout}")
 
     with AppUsbAudDut(adapter_dut, board, config, xflash=True, writeall=writeall) as dut:
         dfu_test = UaDfuApp(dut.features["pid"], dfu_app_type=dfuapp)
 
         initial_version = dfu_test.get_bcd_version()
+        if initial_version != "9.20":
+            print(f"Unexpected initial version {initial_version}, attempting to revert to factory image before starting test, expected 9.20")
+            dfu_test.revert_factory()
+            initial_version = dfu_test.get_bcd_version()
+
+        assert initial_version == "9.20", f"Initial version {initial_version} didn't match expected 9.20"
+
         exp_version1 = "99.01"
         exp_version2 = "99.02"
 
@@ -134,8 +152,7 @@ def test_dfu(pytestconfig, board, config, dfuapp):
 
         dfu_test.download(dfu_bin1)
         version = dfu_test.get_bcd_version()
-        if version != exp_version1:
-            pytest.fail(f"Unexpected version {version} after first upgrade")
+        assert version == exp_version1, f"Unexpected version {version} after first upgrade doesn't match expected {exp_version1}"
 
         # perform the second upgrade
         if "winbuiltin" in config:
@@ -151,42 +168,32 @@ def test_dfu(pytestconfig, board, config, dfuapp):
 
         dfu_test.download(dfu_bin2)
         version = dfu_test.get_bcd_version()
-        if version != exp_version2:
-            pytest.fail(f"Unexpected version {version} after second upgrade")
+        assert version == exp_version2, f"Unexpected version {version} after second upgrade"
 
         upload_file = Path(__file__).parent / "test_dfu_upload.bin"
         dfu_test.upload(upload_file)
         version = dfu_test.get_bcd_version()
-        if version != exp_version2:
-            pytest.fail(f"Unexpected version {version} after reading upgrade image")
+        assert version == exp_version2, f"Unexpected version {version} after reading upgrade image"
+
+        check_upload_file(upload_file)
 
         dfu_test.revert_factory()
         version = dfu_test.get_bcd_version()
-        if version != initial_version:
-            pytest.fail(
-                f"After factory reset, version {version} didn't match initial {initial_version}"
-            )
+        assert version == initial_version, f"After factory reset, version {version} didn't match initial {initial_version}"
 
         # Needed for template app
         # Download (xk_316_mc, upgrade1) first so that when downloading upload_file, a version change can be observed
         if board == "template":
             dfu_test.download(dfu_bin1)
             version = dfu_test.get_bcd_version()
-            if version != exp_version1:
-                pytest.fail(f"Unexpected version {version} after first upgrade")
+            assert version == exp_version1, f"Unexpected version {version} after first upgrade"
 
         dfu_test.download(upload_file)
         upload_file.unlink()
         version = dfu_test.get_bcd_version()
-        if version != exp_version2:
-            pytest.fail(
-                f"Unexpected version {version} after writing the image that was read"
-            )
+        assert version == exp_version2, f"Unexpected version {version} after writing the image that was read"
 
         # Finish by reverting back to the factory image again
         dfu_test.revert_factory()
         version = dfu_test.get_bcd_version()
-        if version != initial_version:
-            pytest.fail(
-                f"Version {version} didn't match initial {initial_version} after final factory reset"
-            )
+        assert version == initial_version, f"Version {version} didn't match initial {initial_version} after final factory reset"

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 XMOS LIMITED.
+# Copyright 2024-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import pytest
 

--- a/tests/test_loopback.py
+++ b/tests/test_loopback.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 XMOS LIMITED.
+# Copyright 2020-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from pathlib import Path
 import pytest

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 XMOS LIMITED.
+# Copyright 2024-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import pytest
 import time

--- a/tests/test_midi_stress.py
+++ b/tests/test_midi_stress.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 XMOS LIMITED.
+# Copyright 2024-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from pathlib import Path
 import pytest

--- a/tests/test_mixer_ctrl.py
+++ b/tests/test_mixer_ctrl.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 XMOS LIMITED.
+# Copyright 2023-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from pathlib import Path
 import pytest

--- a/tests/test_spdif.py
+++ b/tests/test_spdif.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 XMOS LIMITED.
+# Copyright 2022-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from pathlib import Path
 import pytest

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 XMOS LIMITED.
+# Copyright 2024-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import yaml
 from pathlib import Path

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 XMOS LIMITED.
+# Copyright 2022-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from pathlib import Path
 import pytest

--- a/tests/tools/app_configs_autogen/collect_configs.py
+++ b/tests/tools/app_configs_autogen/collect_configs.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 XMOS LIMITED.
+# Copyright 2024-2026 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import subprocess
 import re


### PR DESCRIPTION
Source license updates (2026)
Jenkins gets DFU app from lib_dfu
Fixing 216-MC regression for USB with XUD on tile1 (fixed in lib_xua 5.4.0)
Removing testing of legacy xcommon, moved repo checks and doc build into parallel job

Note: jenkinsfile could do with updating.